### PR TITLE
adjusted login to populate specific error message instead of firebase message

### DIFF
--- a/src/pages/Login/LoginPage.jsx
+++ b/src/pages/Login/LoginPage.jsx
@@ -51,9 +51,19 @@ export default function LoginPage() {
       }
       navigate("/dashboard");
     } catch (error) {
-      setError(error.message);
+      // Mapping Firebase errors to custom messages
+      if (error.code === "auth/user-not-found") {
+        setError("Account not found. Please register.");
+      } else if (error.code === "auth/wrong-password") {
+        setError("Incorrect password. Please try again.");
+      } else if (error.code === "auth/invalid-email") {
+        setError("Invalid email address. Please check your email.");
+      } else {
+        setError("Login failed. Please try again.");
+      }
     }
   };
+
 
   const initialValues = {
     email: "",


### PR DESCRIPTION
For this ticket, I adjusted the error code in the sign up page. Instead of having the usual firebase error, I customized it to give specific error depending if the user signed in, no account found and etc.

TICKET: https://trello.com/c/htjUbWmk/2-when-signing-when-an-account-is-not-found-isnt-customized