### PR TITLE
redirect the create account onto the signup

### DIFF
--- a/src/pages/Login/LoginPage.jsx
+++ b/src/pages/Login/LoginPage.jsx
@@ -185,7 +185,7 @@ export default function LoginPage() {
                       },
                     },
                   }}
-                  onClick={() => navigate("/register")}
+                  onClick={() => navigate("/member/signup")}
                 >
                   Not in the society? <span>Create an Account</span>
                 </Typography>


### PR DESCRIPTION
For this ticket, I adjusted the Create an Account link that was erroring users due to it linking itself to a page that doesn't exist. I went ahead and rerouted the link to the sign up page


TICKET: https://trello.com/c/NCqBEmV3/101-high-priority-create-an-account-keeps-erroring-out