### PR TITLE
Fix dashboard sizing issues at smaller browser widths

### DIFF
--- a/src/components/ContractStatusWidget.jsx
+++ b/src/components/ContractStatusWidget.jsx
@@ -16,9 +16,13 @@ export default function ContractStatusWidget() {
   const { data, loading, error } = useQuery(GET_MEMBER_CONTRACT_STATUS);
 
   const ContractStatueAmount = ({ name, amount }) => (
-    <Box sx={{ textAlign: "center", margin: "10px" }}>
-      <Typography variant="h2">{amount}</Typography>
-      <Typography variant="h4">{name}</Typography>
+    <Box sx={{ textAlign: "center", margin: "10px", flex: 1, minWidth: 0 }}>
+      <Typography sx={{ fontSize: { xs: "1.5rem", sm: "2rem", md: "2.5rem" }, fontWeight: "bold" }}>
+        {amount}
+      </Typography>
+      <Typography sx={{ fontSize: { xs: "0.85rem", sm: "1rem", md: "1.25rem" } }}>
+        {name}
+      </Typography>
     </Box>
   );
 
@@ -41,13 +45,9 @@ export default function ContractStatusWidget() {
         }}
       >
         {[...Array(3)].map((_, index) => (
-          <Box key={index} sx={{ textAlign: "center", margin: "10px" }}>
-            <Typography variant="h2">
-              <Skeleton variant="text" width={50} />
-            </Typography>
-            <Typography variant="h4">
-              <Skeleton variant="text" width={100} />
-            </Typography>
+          <Box key={index} sx={{ textAlign: "center", margin: "10px", flex: 1, minWidth: 0 }}>
+            <Skeleton variant="text" width={50} sx={{ mx: "auto", fontSize: { xs: "1.5rem", md: "2.5rem" } }} />
+            <Skeleton variant="text" width={100} sx={{ mx: "auto", fontSize: { xs: "0.85rem", md: "1.25rem" } }} />
           </Box>
         ))}
       </Box>

--- a/src/pages/Dashboard/MemberDashboard.jsx
+++ b/src/pages/Dashboard/MemberDashboard.jsx
@@ -66,12 +66,18 @@ export const MemberDashboard = () => {
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
+            flexWrap: "wrap",
+            gap: 1,
           }}
         >
-          <Typography variant="h1" fontWeight="bold">
+          <Typography
+            variant="h1"
+            fontWeight="bold"
+            sx={{ fontSize: { xs: "1.6rem", sm: "2rem", md: "2.5rem" }, minWidth: 0 }}
+          >
             Welcome, {member?.firstName || "member"}
           </Typography>
-          <StyledButton onClick={handleLogout} style={{ marginTop: "10px" }}>
+          <StyledButton onClick={handleLogout}>
             Log Out
           </StyledButton>
         </Box>


### PR DESCRIPTION
## Summary
- `MemberDashboard`: Made the Welcome heading responsive so it scales down at smaller screen widths instead of overflowing. Added `flexWrap` and `gap` to the header row so the Log Out button is never pushed off screen.
- `ContractStatusWidget`: Replaced fixed `h2`/`h4` variants with responsive `fontSize` values and added `flex: 1` to each stat column so all three always stay in a single row without wrapping.

Fixes: https://trello.com/c/Wq4NHPgF/133-sizing-issue-with-dashboard