### PR TITLE
Add subscription route guard for unsubscribed members

### DIFF
--- a/src/components/SubscriptionRoute.jsx
+++ b/src/components/SubscriptionRoute.jsx
@@ -1,0 +1,17 @@
+import { Navigate } from "react-router-dom";
+import { useSneakerMember } from "../context/MemberContext";
+import { LoadingCircle } from "./LoadingCircle";
+
+const SubscriptionRoute = ({ children }) => {
+  const { member, loading } = useSneakerMember();
+
+  if (loading) return <LoadingCircle />;
+
+  if (member && !member.isSubscribed) {
+    return <Navigate to="/member/subscriptions" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default SubscriptionRoute;

--- a/src/pages/Dashboard/MemberDashboard.jsx
+++ b/src/pages/Dashboard/MemberDashboard.jsx
@@ -9,7 +9,6 @@ import { ContractListWidget } from "../ContractsPage/ContractListWidget";
 import OnboardModal from "../../components/OnboardModal";
 import { useSneakerMember } from "../../context/MemberContext";
 import { LoadingCircle } from "../../components/LoadingCircle";
-import SubscribeModal from "../../components/SubscribeModal";
 
 export const MemberDashboard = () => {
   const { member, loading } = useSneakerMember();
@@ -49,7 +48,6 @@ export const MemberDashboard = () => {
   }
 
   const isOnboarded = !member.isNewUser;
-  const isSubscribed = member.isSubscribed;
 
   return (
     <Box
@@ -62,7 +60,6 @@ export const MemberDashboard = () => {
       }}
     >
       <OnboardModal isOnboarded={isOnboarded} />
-      <SubscribeModal isSubscribed={isSubscribed} />
       <Box
         sx={{
           flexShrink: 0,

--- a/src/routes/MemberRoutes.jsx
+++ b/src/routes/MemberRoutes.jsx
@@ -11,6 +11,7 @@ import { ChatDashboardMember } from "../pages/Chats/ChatDashboardMember";
 import { GenerateMember } from "../pages/GenerateMember/GenerateMember";
 import { OnboardMember } from "../pages/OnboardMember/OnboardMember";
 import GroupsPage from "../pages/Groups/Groups";
+import SubscriptionRoute from "../components/SubscriptionRoute";
 
 const MemberRoutes = () => {
   return (
@@ -22,7 +23,9 @@ const MemberRoutes = () => {
           path="dashboard"
           element={
             <Layout>
-              <MemberDashboard />
+              <SubscriptionRoute>
+                <MemberDashboard />
+              </SubscriptionRoute>
             </Layout>
           }
         />
@@ -30,7 +33,9 @@ const MemberRoutes = () => {
           path="chats/:id"
           element={
             <Layout>
-              <ChatDashboardMember />
+              <SubscriptionRoute>
+                <ChatDashboardMember />
+              </SubscriptionRoute>
             </Layout>
           }
         />
@@ -38,7 +43,9 @@ const MemberRoutes = () => {
           path="contract/:id"
           element={
             <Layout>
-              <ContractReviewPage />
+              <SubscriptionRoute>
+                <ContractReviewPage />
+              </SubscriptionRoute>
             </Layout>
           }
         />
@@ -46,10 +53,13 @@ const MemberRoutes = () => {
           path="contracts"
           element={
             <Layout>
-              <ContractPage />
+              <SubscriptionRoute>
+                <ContractPage />
+              </SubscriptionRoute>
             </Layout>
           }
         />
+        {/* Excluded from guard — unsubscribed members need access to these */}
         <Route
           path="subscriptions"
           element={
@@ -66,10 +76,12 @@ const MemberRoutes = () => {
             </Layout>
           }
         />
-        <Route path="groups" 
+        <Route path="groups"
           element={
             <Layout>
-              <GroupsPage />
+              <SubscriptionRoute>
+                <GroupsPage />
+              </SubscriptionRoute>
             </Layout>
           }
         />


### PR DESCRIPTION
## Summary
- Created `SubscriptionRoute` component that checks `member.isSubscribed` and redirects to `/member/subscriptions` if false
- Wrapped dashboard, contracts, chats, and groups routes with the guard
- Excluded `onboarding`, `generate`, `subscriptions`, and `subscription-success` from the guard to avoid redirect loops
- Removed `SubscribeModal` from `MemberDashboard` — route-level redirect replaces it

Confirmed with @alanisyates1 on ticket: https://trello.com/c/6uRVIDut