### PR TITLE
Route Messages page and wire up sidebar navigation

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
   List,
@@ -20,6 +21,7 @@ import SettingsModal from "./SettingsModal";
 
 const Sidebar = () => {
   const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
 
   const toggleDrawer = (isOpen) => (event) => {
     if (
@@ -98,7 +100,8 @@ const Sidebar = () => {
             <SidebarItem
               text="Messages"
               icon={<ChatBubbleOutline />}
-              notification={5} // Adding a notification badge with count 5
+              notification={5}
+              onClick={() => navigate("/member/messages")}
             />
           </List>
 

--- a/src/routes/MemberRoutes.jsx
+++ b/src/routes/MemberRoutes.jsx
@@ -11,6 +11,7 @@ import { ChatDashboardMember } from "../pages/Chats/ChatDashboardMember";
 import { GenerateMember } from "../pages/GenerateMember/GenerateMember";
 import { OnboardMember } from "../pages/OnboardMember/OnboardMember";
 import GroupsPage from "../pages/Groups/Groups";
+import ChatSidebar from "../pages/Chats/ChatSidebar";
 
 const MemberRoutes = () => {
   return (
@@ -66,10 +67,18 @@ const MemberRoutes = () => {
             </Layout>
           }
         />
-        <Route path="groups" 
+        <Route path="groups"
           element={
             <Layout>
               <GroupsPage />
+            </Layout>
+          }
+        />
+        <Route
+          path="messages"
+          element={
+            <Layout>
+              <ChatSidebar />
             </Layout>
           }
         />


### PR DESCRIPTION
## Summary
- Added `/member/messages` route in `MemberRoutes.jsx` pointing to `ChatSidebar`
- Added `useNavigate` to `Sidebar.jsx` and wired the Messages sidebar item to navigate to `/member/messages` on both mobile and desktop

Fixes: https://trello.com/c/ky9dAGCV/134-messages-page-not-routed