### PR TITLE
Group display component frontend revamp

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,8 +48,6 @@ function App() {
               <Route path="member/signup/callback" element={<SignUpCallback />} />
               <Route path="user/signup" element={<SignUpUser />} />
               <Route path="user/signup/callback" element={<UserSignupCallback />} />
-              <Route path="/newgrouppage" element={<NewGroupPage />} />
-              <Route path="/groups" element={<Groups />} />
               <Route path="/mysociety" element={<MySociety />} />
 
               <Route

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,8 +16,6 @@ import { LoginV2 } from "./pages/Login/LoginV2";
 import DashboardRouter from "./routes/DashboardRouter";
 import MemberRoutes from "./routes/MemberRoutes";
 import UserRoutes from "./routes/UserRoutes";
-import NewGroupPage from "./pages/GroupsPage/NewGroupPage";
-import Groups from "./pages/Dashboard/Groups";
 import MySociety from "./pages/Dashboard/Discover";
 
 function App() {
@@ -46,10 +44,7 @@ function App() {
               />
               <Route path="member/signup" element={<SignupMember />} />
               <Route path="user/signup" element={<SignUpUser />} />
-              <Route path="/newgrouppage" element={<NewGroupPage />} />
-              <Route path="/groups" element={<Groups />} />
               <Route path="/mysociety" element={<MySociety />} />
-              <Route path="/grouppage" element={<NewGroupPage />} />
 
               <Route
                 path="/dashboard"

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,10 +1,5 @@
 import React, { useState } from "react";
-import {
-  Box,
-  List,
-  IconButton,
-  Drawer,
-} from "@mui/material";
+import { Box, List, IconButton, Drawer } from "@mui/material";
 import {
   ExploreOutlined,
   GroupsOutlined,
@@ -17,6 +12,7 @@ import {
 import SidebarItem from "./SidebarItem";
 import Logo from "../assets/ss-logo-black.svg";
 import SettingsModal from "./SettingsModal";
+import { useNavigate } from "react-router-dom";
 
 const Sidebar = () => {
   const [open, setOpen] = useState(false);
@@ -31,7 +27,7 @@ const Sidebar = () => {
 
     setOpen(isOpen);
   };
-
+  const navigate = useNavigate();
   const [isSettingsModalOpen, setSettingsModalOpen] = useState(false);
 
   const handleSettingsClick = () => {
@@ -71,7 +67,7 @@ const Sidebar = () => {
         >
           {/* Sidebar Content */}
           <Box sx={{ padding: 2, textAlign: "center" }}>
-          <Box
+            <Box
               component="img"
               src={Logo}
               alt="Logo"
@@ -82,7 +78,7 @@ const Sidebar = () => {
                 my: 4,
                 cursor: "pointer",
               }}
-              onClick={() => window.location.href = "/dashboard"}
+              onClick={() => (window.location.href = "/dashboard")}
             />
           </Box>
 
@@ -93,7 +89,11 @@ const Sidebar = () => {
           >
             <SidebarItem text="My Society" icon={<DirectionsRunOutlined />} />
             <SidebarItem text="Discover" icon={<ExploreOutlined />} />
-            <SidebarItem text="Groups" icon={<GroupsOutlined />} />
+            <SidebarItem
+              text="Groups"
+              icon={<GroupsOutlined />}
+              onClick={() => navigate("/member/groups")}
+            />{" "}
             <SidebarItem text="The Vault" icon={<Inventory2Outlined />} />
             <SidebarItem
               text="Messages"
@@ -136,7 +136,7 @@ const Sidebar = () => {
                 my: 4,
                 cursor: "pointer",
               }}
-              onClick={() => window.location.href = "/dashboard"}
+              onClick={() => (window.location.href = "/dashboard")}
             />
           </Box>
 
@@ -147,7 +147,11 @@ const Sidebar = () => {
           >
             <SidebarItem text="My Society" icon={<DirectionsRunOutlined />} />
             <SidebarItem text="Discover" icon={<ExploreOutlined />} />
-            <SidebarItem text="Groups" icon={<GroupsOutlined />} />
+            <SidebarItem
+              text="Groups"
+              icon={<GroupsOutlined />}
+              onClick={() => navigate("/member/groups")}
+            />{" "}
             <SidebarItem text="The Vault" icon={<Inventory2Outlined />} />
             <SidebarItem
               text="Messages"

--- a/src/context/graphql/getGroups.js
+++ b/src/context/graphql/getGroups.js
@@ -1,0 +1,34 @@
+import { gql } from "@apollo/client";
+
+export const GET_GROUPS = gql`
+  query GetGroups {
+    getGroups {
+      id
+      name
+      description
+      avatar
+      members {
+        id
+      }
+      createdAt
+    }
+  }
+`;
+
+export const GET_GROUP = gql`
+  query GetGroup($id: ID!) {
+    getGroup(id: $id) {
+      id
+      name
+      description
+      avatar
+      members {
+        id
+        firstName
+        lastName
+        email
+      }
+      createdAt
+    }
+  }
+`;

--- a/src/pages/Groups/GroupCreationForm.jsx
+++ b/src/pages/Groups/GroupCreationForm.jsx
@@ -52,7 +52,7 @@ const GET_MEMBERS = gql`
   }
 `;
 
-const GroupCreationForm = ({ onClose }) => {
+const GroupCreationForm = () => {
   const [groupName, setGroupName] = useState("");
   const [groupDescription, setGroupDescription] = useState("");
   const [groupAvatar, setGroupAvatar] = useState(null);
@@ -74,7 +74,6 @@ const GroupCreationForm = ({ onClose }) => {
         setSelectedUsersMap({});
         setSearchTerm("");
         setDebouncedSearchTerm("");
-        onClose?.();
       },
     },
   );
@@ -119,6 +118,16 @@ const GroupCreationForm = ({ onClose }) => {
     }
   };
 
+  const handleReset = () => {
+    setGroupName("");
+    setGroupDescription("");
+    setGroupAvatar(null);
+    setSelectedUsers([]);
+    setSelectedUsersMap({});
+    setSearchTerm("");
+    setDebouncedSearchTerm("");
+  };
+
   const handleCreate = () => {
     if (!groupName.trim()) {
       alert("Please enter a group name.");
@@ -141,16 +150,24 @@ const GroupCreationForm = ({ onClose }) => {
     <Box
       sx={{
         width: "100%",
-        p: 3,
-        bgcolor: "background.paper",
-        borderRadius: 2,
+        maxWidth: 700,
+        p: 4,
+        bgcolor: "#111",
+        borderRadius: 3,
+        color: "#fff",
+        boxShadow: "0 8px 24px rgba(0,0,0,0.35)",
       }}
     >
-      <Typography variant="h4" mb={2} align="center" sx={{ color: "#FFD100" }}>
+      <Typography
+        variant="h5"
+        mb={3}
+        align="center"
+        sx={{ color: "#FFD100", fontWeight: 700 }}
+      >
         Create a Group
       </Typography>
 
-      <Box textAlign="center" mb={2}>
+      <Box textAlign="center" mb={3}>
         <input
           accept="image/*"
           style={{ display: "none" }}
@@ -162,11 +179,15 @@ const GroupCreationForm = ({ onClose }) => {
           <IconButton component="span">
             <Avatar
               src={groupAvatar || ""}
-              sx={{ width: 80, height: 80, mx: "auto" }}
+              sx={{ width: 80, height: 80, mx: "auto", bgcolor: "#333" }}
             />
           </IconButton>
         </label>
-        <Typography variant="caption" display="block">
+        <Typography
+          variant="caption"
+          display="block"
+          sx={{ color: "#b3b3b3", mt: 1 }}
+        >
           Upload Group Photo
         </Typography>
       </Box>
@@ -177,7 +198,11 @@ const GroupCreationForm = ({ onClose }) => {
         variant="outlined"
         value={groupName}
         onChange={(e) => setGroupName(e.target.value)}
-        sx={{ mb: 2 }}
+        sx={{
+          mb: 2,
+          "& .MuiInputBase-root": { bgcolor: "#000", color: "#fff" },
+          "& .MuiInputLabel-root": { color: "#b3b3b3" },
+        }}
       />
 
       <TextField
@@ -188,7 +213,11 @@ const GroupCreationForm = ({ onClose }) => {
         rows={3}
         value={groupDescription}
         onChange={(e) => setGroupDescription(e.target.value)}
-        sx={{ mb: 2 }}
+        sx={{
+          mb: 2,
+          "& .MuiInputBase-root": { bgcolor: "#000", color: "#fff" },
+          "& .MuiInputLabel-root": { color: "#b3b3b3" },
+        }}
       />
 
       <TextField
@@ -197,16 +226,26 @@ const GroupCreationForm = ({ onClose }) => {
         variant="outlined"
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
-        sx={{ mb: 1 }}
+        sx={{
+          mb: 1,
+          "& .MuiInputBase-root": { bgcolor: "#000", color: "#fff" },
+          "& .MuiInputLabel-root": { color: "#b3b3b3" },
+        }}
       />
 
       <Stack sx={{ maxHeight: 150, overflowY: "auto", mb: 2 }}>
-        {membersLoading && <Typography>Loading members...</Typography>}
+        {membersLoading && (
+          <Typography variant="body2" sx={{ color: "#b3b3b3" }}>
+            Loading members...
+          </Typography>
+        )}
 
         {!membersLoading &&
           users.length === 0 &&
           debouncedSearchTerm !== "" && (
-            <Typography>No members found</Typography>
+            <Typography variant="body2" sx={{ color: "#b3b3b3" }}>
+              No members found
+            </Typography>
           )}
 
         {!membersLoading &&
@@ -220,22 +259,32 @@ const GroupCreationForm = ({ onClose }) => {
                 display="flex"
                 justifyContent="space-between"
                 alignItems="center"
-                py={1}
+                py={0.75}
               >
-                <Typography>{fullName}</Typography>
+                <Typography variant="body2">{fullName}</Typography>
 
                 <Button
                   size="small"
                   variant={isSelected ? "outlined" : "contained"}
                   onClick={() => toggleUserSelection(user)}
+                  sx={{
+                    textTransform: "none",
+                    fontSize: 12,
+                    bgcolor: isSelected ? "transparent" : "#FFD100",
+                    color: isSelected ? "#FFD100" : "#000",
+                    borderColor: "#FFD100",
+                    "&:hover": {
+                      bgcolor: isSelected ? "rgba(255,209,0,0.08)" : "#ffde33",
+                    },
+                  }}
                 >
                   {isSelected ? (
                     <>
-                      <CheckIcon fontSize="small" /> Added
+                      <CheckIcon fontSize="small" sx={{ mr: 0.5 }} /> Added
                     </>
                   ) : (
                     <>
-                      <AddIcon fontSize="small" /> Add
+                      <AddIcon fontSize="small" sx={{ mr: 0.5 }} /> Add
                     </>
                   )}
                 </Button>
@@ -244,37 +293,54 @@ const GroupCreationForm = ({ onClose }) => {
           })}
       </Stack>
 
-      <Box sx={{ mb: 2 }}>
-        {selectedUsers.length > 0 && (
-          <>
-            <Typography variant="subtitle1" gutterBottom>
-              Selected Members
-            </Typography>
+      {selectedUsers.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="subtitle2" gutterBottom sx={{ fontWeight: 700 }}>
+            Selected Members
+          </Typography>
 
-            {selectedUsers.map((id) => {
-              const user = selectedUsersMap[id];
-              if (!user) return null;
+          {selectedUsers.map((id) => {
+            const user = selectedUsersMap[id];
+            if (!user) return null;
 
-              return (
-                <Box key={id} display="flex" alignItems="center" gap={1}>
-                  <Typography>
-                    {user.firstName} {user.lastName}
-                  </Typography>
-                  <Button
-                    size="small"
-                    onClick={() => toggleUserSelection(user)}
-                  >
-                    ×
-                  </Button>
-                </Box>
-              );
-            })}
-          </>
-        )}
-      </Box>
+            return (
+              <Box
+                key={id}
+                display="flex"
+                alignItems="center"
+                gap={1}
+                sx={{ mb: 0.5 }}
+              >
+                <Typography variant="body2">
+                  {user.firstName} {user.lastName}
+                </Typography>
+                <Button
+                  size="small"
+                  onClick={() => toggleUserSelection(user)}
+                  sx={{
+                    minWidth: 0,
+                    px: 1,
+                    color: "#ff6b6b",
+                    textTransform: "none",
+                  }}
+                >
+                  ×
+                </Button>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
 
-      <Box textAlign="right">
-        <Button sx={{ mr: 2 }} onClick={onClose}>
+      <Box textAlign="right" mt={1}>
+        <Button
+          sx={{
+            mr: 2,
+            color: "#ff6b6b",
+            textTransform: "none",
+          }}
+          onClick={handleReset}
+        >
           Cancel
         </Button>
 
@@ -282,13 +348,20 @@ const GroupCreationForm = ({ onClose }) => {
           onClick={handleCreate}
           variant="contained"
           disabled={creating || !groupName.trim()}
+          sx={{
+            textTransform: "none",
+            fontWeight: 700,
+            bgcolor: "#FFD100",
+            color: "#000",
+            "&:hover": { bgcolor: "#ffde33" },
+          }}
         >
           {creating ? "Creating..." : "Create Group"}
         </Button>
       </Box>
 
       {createError && (
-        <Typography color="error" mt={2}>
+        <Typography color="error" mt={2} variant="body2">
           {createError.message}
         </Typography>
       )}

--- a/src/pages/Groups/GroupCreationForm.jsx
+++ b/src/pages/Groups/GroupCreationForm.jsx
@@ -11,6 +11,7 @@ import {
 import AddIcon from "@mui/icons-material/Add";
 import CheckIcon from "@mui/icons-material/Check";
 import { gql, useMutation, useLazyQuery } from "@apollo/client";
+import { GET_GROUPS } from "../../context/graphql/getGroups";
 
 const CREATE_GROUP = gql`
   mutation CreateGroup(
@@ -51,7 +52,7 @@ const GET_MEMBERS = gql`
   }
 `;
 
-const GroupCreationForm = () => {
+const GroupCreationForm = ({ onClose }) => {
   const [groupName, setGroupName] = useState("");
   const [groupDescription, setGroupDescription] = useState("");
   const [groupAvatar, setGroupAvatar] = useState(null);
@@ -63,6 +64,8 @@ const GroupCreationForm = () => {
   const [createGroup, { loading: creating, error: createError }] = useMutation(
     CREATE_GROUP,
     {
+      refetchQueries: [{ query: GET_GROUPS }],
+      awaitRefetchQueries: true,
       onCompleted: () => {
         setGroupName("");
         setGroupDescription("");
@@ -70,6 +73,8 @@ const GroupCreationForm = () => {
         setSelectedUsers([]);
         setSelectedUsersMap({});
         setSearchTerm("");
+        setDebouncedSearchTerm("");
+        onClose?.();
       },
     },
   );
@@ -81,11 +86,12 @@ const GroupCreationForm = () => {
     const handler = setTimeout(() => {
       setDebouncedSearchTerm(searchTerm);
     }, 500);
+
     return () => clearTimeout(handler);
   }, [searchTerm]);
 
   useEffect(() => {
-    if (debouncedSearchTerm.length > 0) {
+    if (debouncedSearchTerm.trim().length > 0) {
       fetchMembers({ variables: { searchTerm: debouncedSearchTerm } });
     }
   }, [debouncedSearchTerm, fetchMembers]);
@@ -94,9 +100,9 @@ const GroupCreationForm = () => {
     if (selectedUsers.includes(user.id)) {
       setSelectedUsers((prev) => prev.filter((id) => id !== user.id));
       setSelectedUsersMap((prev) => {
-        const newMap = { ...prev };
-        delete newMap[user.id];
-        return newMap;
+        const next = { ...prev };
+        delete next[user.id];
+        return next;
       });
     } else {
       setSelectedUsers((prev) => [...prev, user.id]);
@@ -114,21 +120,17 @@ const GroupCreationForm = () => {
   };
 
   const handleCreate = () => {
-    if (!groupName) {
+    if (!groupName.trim()) {
       alert("Please enter a group name.");
       return;
     }
 
     const variables = {
-      name: groupName,
-      description: groupDescription,
-      // avatar: groupAvatar,
-      avatar: "https://via.placeholder.com/150", // TEMP: mock URL
+      name: groupName.trim(),
+      description: groupDescription.trim(),
+      avatar: groupAvatar || "https://via.placeholder.com/150",
+      memberIds: selectedUsers,
     };
-
-    if (selectedUsers.length > 0) {
-      variables.memberIds = selectedUsers;
-    }
 
     createGroup({ variables });
   };
@@ -148,9 +150,7 @@ const GroupCreationForm = () => {
         variant="h4"
         mb={2}
         align="center"
-        sx={{
-          color: "#FFD100",
-        }}
+        sx={{ color: "#FFD100" }}
       >
         Create a Group
       </Typography>
@@ -207,19 +207,16 @@ const GroupCreationForm = () => {
 
       <Stack sx={{ maxHeight: 150, overflowY: "auto", mb: 2 }}>
         {membersLoading && <Typography>Loading members...</Typography>}
-        {createError && (
-          <Typography color="error">{createError.message}</Typography>
-        )}
+
         {!membersLoading &&
           users.length === 0 &&
-          debouncedSearchTerm !== "" && (
-            <Typography>No members found</Typography>
-          )}
+          debouncedSearchTerm !== "" && <Typography>No members found</Typography>}
 
-        {/* User list */}
         {!membersLoading &&
           users.map((user) => {
             const fullName = `${user.firstName} ${user.lastName}`;
+            const isSelected = selectedUsers.includes(user.id);
+
             return (
               <Box
                 key={user.id}
@@ -229,14 +226,13 @@ const GroupCreationForm = () => {
                 py={1}
               >
                 <Typography>{fullName}</Typography>
+
                 <Button
                   size="small"
-                  variant={
-                    selectedUsers.includes(user.id) ? "outlined" : "contained"
-                  }
+                  variant={isSelected ? "outlined" : "contained"}
                   onClick={() => toggleUserSelection(user)}
                 >
-                  {selectedUsers.includes(user.id) ? (
+                  {isSelected ? (
                     <>
                       <CheckIcon fontSize="small" /> Added
                     </>
@@ -249,42 +245,43 @@ const GroupCreationForm = () => {
               </Box>
             );
           })}
-
-        {/* Selected users section */}
-        <Box sx={{ mb: 2 }}>
-          {selectedUsers.length > 0 && (
-            <>
-              <Typography variant="subtitle1" gutterBottom>
-                Selected Members
-              </Typography>
-              {selectedUsers.map((id) => {
-                const user = selectedUsersMap[id];
-                if (!user) return null;
-                return (
-                  <Box key={id} display="flex" alignItems="center">
-                    <Typography>
-                      {user.firstName} {user.lastName}
-                    </Typography>
-                    <Button
-                      size="small"
-                      onClick={() => toggleUserSelection(user)}
-                    >
-                      ×
-                    </Button>
-                  </Box>
-                );
-              })}
-            </>
-          )}
-        </Box>
       </Stack>
 
+      <Box sx={{ mb: 2 }}>
+        {selectedUsers.length > 0 && (
+          <>
+            <Typography variant="subtitle1" gutterBottom>
+              Selected Members
+            </Typography>
+
+            {selectedUsers.map((id) => {
+              const user = selectedUsersMap[id];
+              if (!user) return null;
+
+              return (
+                <Box key={id} display="flex" alignItems="center" gap={1}>
+                  <Typography>
+                    {user.firstName} {user.lastName}
+                  </Typography>
+                  <Button size="small" onClick={() => toggleUserSelection(user)}>
+                    ×
+                  </Button>
+                </Box>
+              );
+            })}
+          </>
+        )}
+      </Box>
+
       <Box textAlign="right">
-        <Button sx={{ mr: 2 }}>Cancel</Button>
+        <Button sx={{ mr: 2 }} onClick={onClose}>
+          Cancel
+        </Button>
+
         <Button
           onClick={handleCreate}
           variant="contained"
-          disabled={creating || !groupName}
+          disabled={creating || !groupName.trim()}
         >
           {creating ? "Creating..." : "Create Group"}
         </Button>

--- a/src/pages/Groups/GroupCreationForm.jsx
+++ b/src/pages/Groups/GroupCreationForm.jsx
@@ -146,12 +146,7 @@ const GroupCreationForm = ({ onClose }) => {
         borderRadius: 2,
       }}
     >
-      <Typography
-        variant="h4"
-        mb={2}
-        align="center"
-        sx={{ color: "#FFD100" }}
-      >
+      <Typography variant="h4" mb={2} align="center" sx={{ color: "#FFD100" }}>
         Create a Group
       </Typography>
 
@@ -210,7 +205,9 @@ const GroupCreationForm = ({ onClose }) => {
 
         {!membersLoading &&
           users.length === 0 &&
-          debouncedSearchTerm !== "" && <Typography>No members found</Typography>}
+          debouncedSearchTerm !== "" && (
+            <Typography>No members found</Typography>
+          )}
 
         {!membersLoading &&
           users.map((user) => {
@@ -263,7 +260,10 @@ const GroupCreationForm = ({ onClose }) => {
                   <Typography>
                     {user.firstName} {user.lastName}
                   </Typography>
-                  <Button size="small" onClick={() => toggleUserSelection(user)}>
+                  <Button
+                    size="small"
+                    onClick={() => toggleUserSelection(user)}
+                  >
                     ×
                   </Button>
                 </Box>

--- a/src/pages/Groups/GroupDisplay.jsx
+++ b/src/pages/Groups/GroupDisplay.jsx
@@ -40,194 +40,192 @@ const GroupDisplay = ({ currentUserId, currentUserLoading }) => {
     <Box
       sx={{
         width: "100%",
-        bgcolor: "#000",
-        py: 2,
-        display: "flex",
-        justifyContent: "center",
+        maxWidth: 520,
+        bgcolor: "#8e8e8e",
+        borderRadius: 3,
+        overflow: "hidden",
+        boxShadow: "0 8px 24px rgba(0,0,0,0.35)",
       }}
     >
-      <Box
-        sx={{
-          width: "100%",
-          maxWidth: 420,
-          bgcolor: "gray",
-          borderRadius: 2,
-          overflow: "hidden",
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        <Box sx={{ bgcolor: "gray", p: 1 }}>
-          <Box
+      {/* Tabs */}
+      <Box sx={{ bgcolor: "#8e8e8e", p: 1.5 }}>
+        <Box
+          sx={{
+            display: "flex",
+            bgcolor: "#232323",
+            borderRadius: "999px",
+            p: 0.5,
+          }}
+        >
+          <Button
+            onClick={() => setTab("trending")}
             sx={{
-              display: "flex",
-              bgcolor: "#232323",
+              flex: 1,
               borderRadius: "999px",
-              p: 0.5,
-            }}
-          >
-            <Button
-              onClick={() => setTab("trending")}
-              sx={{
-                flex: 1,
-                borderRadius: "999px",
-                textTransform: "none",
-                fontWeight: 700,
-                fontSize: 14,
-                bgcolor: tab === "trending" ? "#FFD100" : "transparent",
-                color: tab === "trending" ? "#000" : "#FFD100",
-                "&:hover": {
-                  bgcolor: tab === "trending" ? "#ffde33" : "transparent",
-                },
-              }}
-            >
-              Trending Groups
-            </Button>
-
-            <Button
-              onClick={() => setTab("my")}
-              sx={{
-                flex: 1,
-                borderRadius: "999px",
-                textTransform: "none",
-                fontWeight: 700,
-                fontSize: 14,
-                bgcolor: tab === "my" ? "#FFD100" : "transparent",
-                color: tab === "my" ? "#000" : "#FFD100",
-                "&:hover": {
-                  bgcolor: tab === "my" ? "#ffde33" : "transparent",
-                },
-              }}
-            >
-              My Groups
-            </Button>
-          </Box>
-        </Box>
-
-        <Box sx={{ px: 2, pt: 1.5, pb: 1 }}>
-          <TextField
-            fullWidth
-            size="small"
-            variant="outlined"
-            placeholder="Search for a group"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            sx={{
-              bgcolor: "black",
-              borderRadius: "999px",
-              "& fieldset": { border: "none" },
-              "& .MuiInputBase-input": {
-                px: 2,
-                py: 1.2,
-                color: "#fff",
+              textTransform: "none",
+              fontWeight: 700,
+              fontSize: 14,
+              bgcolor: tab === "trending" ? "#FFD100" : "transparent",
+              color: tab === "trending" ? "#000" : "#FFD100",
+              "&:hover": {
+                bgcolor: tab === "trending" ? "#ffde33" : "transparent",
               },
             }}
-          />
+          >
+            Trending Groups
+          </Button>
+
+          <Button
+            onClick={() => setTab("my")}
+            sx={{
+              flex: 1,
+              borderRadius: "999px",
+              textTransform: "none",
+              fontWeight: 700,
+              fontSize: 14,
+              bgcolor: tab === "my" ? "#FFD100" : "transparent",
+              color: tab === "my" ? "#000" : "#FFD100",
+              "&:hover": {
+                bgcolor: tab === "my" ? "#ffde33" : "transparent",
+              },
+            }}
+          >
+            My Groups
+          </Button>
         </Box>
+      </Box>
 
-        <Box sx={{ bgcolor: "gray", flex: 1 }}>
-          {loading && (
-            <Typography sx={{ px: 2, py: 2 }}>Loading groups...</Typography>
-          )}
+      {/* Search */}
+      <Box sx={{ px: 2, pt: 1.5, pb: 1, bgcolor: "#8e8e8e" }}>
+        <TextField
+          fullWidth
+          size="small"
+          variant="outlined"
+          placeholder="Search for a group"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{
+            bgcolor: "#000",
+            borderRadius: "999px",
+            "& fieldset": { border: "none" },
+            "& .MuiInputBase-input": {
+              px: 2,
+              py: 1.2,
+              color: "#fff",
+            },
+          }}
+        />
+      </Box>
 
-          {!loading && tab === "my" && currentUserLoading && (
-            <Typography sx={{ px: 2, py: 2 }}>
-              Loading your groups...
+      {/* List / Messages */}
+      <Box sx={{ bgcolor: "#8e8e8e", flex: 1 }}>
+        {loading && (
+          <Typography sx={{ px: 2, py: 2 }} color="#232323">
+            Loading groups...
+          </Typography>
+        )}
+
+        {!loading && tab === "my" && currentUserLoading && (
+          <Typography sx={{ px: 2, py: 2 }} color="#232323">
+            Loading your groups...
+          </Typography>
+        )}
+
+        {error && (
+          <Typography sx={{ px: 2, py: 2 }} color="error">
+            Failed to load groups
+          </Typography>
+        )}
+
+        {!loading &&
+          !error &&
+          baseGroups !== null &&
+          tab === "trending" &&
+          allGroups.length === 0 && (
+            <Typography sx={{ px: 2, py: 2 }} color="#232323">
+              No groups have been created yet.
             </Typography>
           )}
 
-          {error && (
-            <Typography sx={{ px: 2, py: 2 }} color="error">
-              Failed to load groups
+        {!loading &&
+          !error &&
+          baseGroups !== null &&
+          tab === "my" &&
+          baseGroups.length === 0 && (
+            <Typography sx={{ px: 2, py: 2 }} color="#232323">
+              You haven't joined any groups yet.
             </Typography>
           )}
 
-          {!loading &&
-            !error &&
-            baseGroups !== null &&
-            tab === "trending" &&
-            allGroups.length === 0 && (
-              <Typography sx={{ px: 2, py: 2 }} color="text.secondary">
-                No groups have been created yet.
-              </Typography>
-            )}
+        {!loading &&
+          !error &&
+          baseGroups !== null &&
+          baseGroups.length > 0 &&
+          filteredGroups &&
+          filteredGroups.length === 0 && (
+            <Typography sx={{ px: 2, py: 2 }} color="#232323">
+              No groups match your search.
+            </Typography>
+          )}
 
-          {!loading &&
-            !error &&
-            baseGroups !== null &&
-            tab === "my" &&
-            baseGroups.length === 0 && (
-              <Typography sx={{ px: 2, py: 2 }} color="text.secondary">
-                You haven't joined any groups yet.
-              </Typography>
-            )}
+        {!loading &&
+          !error &&
+          filteredGroups &&
+          filteredGroups.map((group) => {
+            const memberCount = (group.members || []).length;
 
-          {!loading &&
-            !error &&
-            baseGroups !== null &&
-            baseGroups.length > 0 &&
-            filteredGroups.length === 0 && (
-              <Typography sx={{ px: 2, py: 2 }} color="text.secondary">
-                No groups match your search.
-              </Typography>
-            )}
+            return (
+              <Box
+                key={group.id}
+                onClick={() => handleGroupClick(group)}
+                sx={{
+                  px: 2,
+                  py: 1.5,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  borderBottom: "1px solid #d0d0d0",
+                  cursor: "pointer",
+                  "&:hover": {
+                    bgcolor: "#a2a2a2",
+                  },
+                }}
+              >
+                <Stack spacing={0.3}>
+                  <Typography fontWeight={700} fontSize={14} color="#000">
+                    {group.name}
+                  </Typography>
+                  <Typography fontSize={12} sx={{ color: "#333" }}>
+                    {memberCount} {memberCount === 1 ? "member" : "members"}
+                  </Typography>
+                </Stack>
 
-          {!loading &&
-            !error &&
-            filteredGroups &&
-            filteredGroups.map((group) => {
-              const memberCount = (group.members || []).length;
-
-              return (
                 <Box
-                  key={group.id}
-                  onClick={() => handleGroupClick(group)}
                   sx={{
-                    px: 2,
-                    py: 1.5,
+                    width: 70,
+                    height: 40,
+                    borderRadius: 1,
+                    overflow: "hidden",
                     display: "flex",
                     alignItems: "center",
-                    justifyContent: "space-between",
-                    borderBottom: "1px solid #d0d0d0",
-                    cursor: "pointer",
+                    justifyContent: "center",
+                    bgcolor: group.avatar ? "transparent" : "#2b2b2b",
+                    color: group.avatar ? "inherit" : "#FFD100",
+                    fontWeight: 700,
+                    fontSize: 18,
+                    textTransform: "uppercase",
+                    backgroundImage: group.avatar
+                      ? `url(${group.avatar})`
+                      : "none",
+                    backgroundSize: "cover",
+                    backgroundPosition: "center",
                   }}
                 >
-                  <Stack spacing={0.3}>
-                    <Typography fontWeight={700} fontSize={14}>
-                      {group.name}
-                    </Typography>
-                    <Typography fontSize={12} color="text.secondary">
-                      {memberCount} {memberCount === 1 ? "member" : "members"}
-                    </Typography>
-                  </Stack>
-
-                  <Box
-                    sx={{
-                      width: 70,
-                      height: 40,
-                      borderRadius: 1,
-                      overflow: "hidden",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      bgcolor: group.avatar ? "transparent" : "#2b2b2b",
-                      color: group.avatar ? "inherit" : "#FFD100",
-                      fontWeight: 700,
-                      fontSize: 18,
-                      textTransform: "uppercase",
-                      backgroundImage: group.avatar
-                        ? `url(${group.avatar})`
-                        : "none",
-                      backgroundSize: "cover",
-                      backgroundPosition: "center",
-                    }}
-                  >
-                    {!group.avatar && (group.name?.trim()?.[0] || "G")}
-                  </Box>
+                  {!group.avatar && (group.name?.trim()?.[0] || "G")}
                 </Box>
-              );
-            })}
-        </Box>
+              </Box>
+            );
+          })}
       </Box>
     </Box>
   );

--- a/src/pages/Groups/GroupDisplay.jsx
+++ b/src/pages/Groups/GroupDisplay.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "@apollo/client";
 import { GET_GROUPS } from "../../context/graphql/getGroups";
 
-const GroupDisplay = ({ currentUserId }) => {
+const GroupDisplay = ({ currentUserId, currentUserLoading }) => {
   const [tab, setTab] = useState("trending");
   const [search, setSearch] = useState("");
   const navigate = useNavigate();
@@ -12,18 +12,25 @@ const GroupDisplay = ({ currentUserId }) => {
   const { data, loading, error } = useQuery(GET_GROUPS);
   const allGroups = data?.getGroups || [];
 
-  const filtered = useMemo(() => {
-    const baseList =
-      tab === "my"
-        ? allGroups.filter((group) =>
-            (group.members || []).some((member) => member.id === currentUserId),
-          )
-        : allGroups;
+  const baseGroups = useMemo(() => {
+    if (tab === "my") {
+      if (currentUserLoading) return null;
 
-    return baseList.filter((group) =>
+      return allGroups.filter((group) =>
+        (group.members || []).some((member) => member.id === currentUserId),
+      );
+    }
+
+    return allGroups;
+  }, [tab, allGroups, currentUserId, currentUserLoading]);
+
+  const filteredGroups = useMemo(() => {
+    if (baseGroups === null) return null;
+
+    return baseGroups.filter((group) =>
       group.name.toLowerCase().includes(search.toLowerCase()),
     );
-  }, [tab, allGroups, search, currentUserId]);
+  }, [baseGroups, search]);
 
   const handleGroupClick = (group) => {
     navigate(`/member/groups/${group.id}`);
@@ -123,21 +130,52 @@ const GroupDisplay = ({ currentUserId }) => {
             <Typography sx={{ px: 2, py: 2 }}>Loading groups...</Typography>
           )}
 
+          {!loading && tab === "my" && currentUserLoading && (
+            <Typography sx={{ px: 2, py: 2 }}>
+              Loading your groups...
+            </Typography>
+          )}
+
           {error && (
             <Typography sx={{ px: 2, py: 2 }} color="error">
               Failed to load groups
             </Typography>
           )}
 
-          {!loading && !error && filtered.length === 0 && (
-            <Typography sx={{ px: 2, py: 2 }} color="text.secondary">
-              No groups found
-            </Typography>
-          )}
+          {!loading &&
+            !error &&
+            baseGroups !== null &&
+            tab === "trending" &&
+            allGroups.length === 0 && (
+              <Typography sx={{ px: 2, py: 2 }} color="text.secondary">
+                No groups have been created yet.
+              </Typography>
+            )}
 
           {!loading &&
             !error &&
-            filtered.map((group) => {
+            baseGroups !== null &&
+            tab === "my" &&
+            baseGroups.length === 0 && (
+              <Typography sx={{ px: 2, py: 2 }} color="text.secondary">
+                You haven't joined any groups yet.
+              </Typography>
+            )}
+
+          {!loading &&
+            !error &&
+            baseGroups !== null &&
+            baseGroups.length > 0 &&
+            filteredGroups.length === 0 && (
+              <Typography sx={{ px: 2, py: 2 }} color="text.secondary">
+                No groups match your search.
+              </Typography>
+            )}
+
+          {!loading &&
+            !error &&
+            filteredGroups &&
+            filteredGroups.map((group) => {
               const memberCount = (group.members || []).length;
 
               return (
@@ -167,15 +205,25 @@ const GroupDisplay = ({ currentUserId }) => {
                     sx={{
                       width: 70,
                       height: 40,
-                      bgcolor: "#c4c4c4",
                       borderRadius: 1,
+                      overflow: "hidden",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: group.avatar ? "transparent" : "#2b2b2b",
+                      color: group.avatar ? "inherit" : "#FFD100",
+                      fontWeight: 700,
+                      fontSize: 18,
+                      textTransform: "uppercase",
                       backgroundImage: group.avatar
                         ? `url(${group.avatar})`
-                        : "",
+                        : "none",
                       backgroundSize: "cover",
                       backgroundPosition: "center",
                     }}
-                  />
+                  >
+                    {!group.avatar && (group.name?.trim()?.[0] || "G")}
+                  </Box>
                 </Box>
               );
             })}

--- a/src/pages/Groups/GroupDisplay.jsx
+++ b/src/pages/Groups/GroupDisplay.jsx
@@ -1,43 +1,31 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Box, Button, TextField, Typography, Stack } from "@mui/material";
 import { useNavigate } from "react-router-dom";
-import { gql } from "@apollo/client";
 import { useQuery } from "@apollo/client";
-import { GET_GROUPS } from "./groups.gql";
+import { GET_GROUPS } from "../../context/graphql/getGroups";
+import GroupCreationForm from "./GroupCreationForm";
 
-export const GET_GROUPS = gql`
-  query GetGroups {
-    groups {
-      id
-      name
-      description
-      avatar
-      members {
-        id
-      }
-      createdAt
-    }
-  }
-`;
-
-const GroupDisplay = () => {
+const GroupDisplay = ({ currentUserId }) => {
   const [tab, setTab] = useState("trending");
   const [search, setSearch] = useState("");
   const [openCreate, setOpenCreate] = useState(false);
   const navigate = useNavigate();
 
   const { data, loading, error } = useQuery(GET_GROUPS);
-
-  const allGroups = data?.groups || [];
+  const allGroups = data?.getGroups || [];
 
   const filtered = useMemo(() => {
-    const list = tab === "trending" ? allGroups : allGroups;
-    return list.filter((g) =>
-      g.name.toLowerCase().includes(search.toLowerCase())
-    );
-  }, [tab, allGroups, search]);
+    const baseList =
+      tab === "my"
+        ? allGroups.filter((group) =>
+            (group.members || []).some((member) => member.id === currentUserId),
+          )
+        : allGroups;
 
-  const displayedGroups = filtered;
+    return baseList.filter((group) =>
+      group.name.toLowerCase().includes(search.toLowerCase()),
+    );
+  }, [tab, allGroups, search, currentUserId]);
 
   const handleGroupClick = (group) => {
     navigate(`/groups/${group.id}`);
@@ -64,7 +52,6 @@ const GroupDisplay = () => {
           flexDirection: "column",
         }}
       >
-        {/* Tabs */}
         <Box sx={{ bgcolor: "gray", p: 1 }}>
           <Box
             sx={{
@@ -91,6 +78,7 @@ const GroupDisplay = () => {
             >
               Trending Groups
             </Button>
+
             <Button
               onClick={() => setTab("my")}
               sx={{
@@ -111,7 +99,6 @@ const GroupDisplay = () => {
           </Box>
         </Box>
 
-        {/* Search */}
         <Box sx={{ px: 2, pt: 1.5, pb: 1 }}>
           <TextField
             fullWidth
@@ -133,18 +120,18 @@ const GroupDisplay = () => {
           />
         </Box>
 
-        {/* tabs + search stay the same */}
-
         <Box sx={{ bgcolor: "gray", flex: 1 }}>
           {loading && (
             <Typography sx={{ px: 2, py: 2 }}>Loading groups...</Typography>
           )}
+
           {error && (
             <Typography sx={{ px: 2, py: 2 }} color="error">
               Failed to load groups
             </Typography>
           )}
-          {!loading && !error && displayedGroups.length === 0 && (
+
+          {!loading && !error && filtered.length === 0 && (
             <Typography sx={{ px: 2, py: 2 }} color="text.secondary">
               No groups found
             </Typography>
@@ -152,7 +139,7 @@ const GroupDisplay = () => {
 
           {!loading &&
             !error &&
-            displayedGroups.map((group) => (
+            filtered.map((group) => (
               <Box
                 key={group.id}
                 onClick={() => handleGroupClick(group)}
@@ -190,7 +177,6 @@ const GroupDisplay = () => {
             ))}
         </Box>
 
-        {/* Bottom create button */}
         <Box
           sx={{
             bgcolor: "#000",
@@ -202,7 +188,7 @@ const GroupDisplay = () => {
           <Button
             onClick={() => setOpenCreate(true)}
             sx={{
-              minWidth: 80,
+              minWidth: 100,
               height: 40,
               borderRadius: 2,
               bgcolor: "#FFD100",
@@ -216,6 +202,25 @@ const GroupDisplay = () => {
           </Button>
         </Box>
       </Box>
+
+      {openCreate && (
+        <Box
+          sx={{
+            position: "fixed",
+            inset: 0,
+            bgcolor: "rgba(0,0,0,0.6)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            p: 2,
+            zIndex: 1300,
+          }}
+        >
+          <Box sx={{ width: "100%", maxWidth: 520 }}>
+            <GroupCreationForm onClose={() => setOpenCreate(false)} />
+          </Box>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/pages/Groups/GroupDisplay.jsx
+++ b/src/pages/Groups/GroupDisplay.jsx
@@ -3,12 +3,10 @@ import { Box, Button, TextField, Typography, Stack } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@apollo/client";
 import { GET_GROUPS } from "../../context/graphql/getGroups";
-import GroupCreationForm from "./GroupCreationForm";
 
 const GroupDisplay = ({ currentUserId }) => {
   const [tab, setTab] = useState("trending");
   const [search, setSearch] = useState("");
-  const [openCreate, setOpenCreate] = useState(false);
   const navigate = useNavigate();
 
   const { data, loading, error } = useQuery(GET_GROUPS);
@@ -28,7 +26,7 @@ const GroupDisplay = ({ currentUserId }) => {
   }, [tab, allGroups, search, currentUserId]);
 
   const handleGroupClick = (group) => {
-    navigate(`/groups/${group.id}`);
+    navigate(`/member/groups/${group.id}`);
   };
 
   return (
@@ -139,88 +137,50 @@ const GroupDisplay = ({ currentUserId }) => {
 
           {!loading &&
             !error &&
-            filtered.map((group) => (
-              <Box
-                key={group.id}
-                onClick={() => handleGroupClick(group)}
-                sx={{
-                  px: 2,
-                  py: 1.5,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  borderBottom: "1px solid #d0d0d0",
-                  cursor: "pointer",
-                }}
-              >
-                <Stack spacing={0.3}>
-                  <Typography fontWeight={700} fontSize={14}>
-                    {group.name}
-                  </Typography>
-                  <Typography fontSize={12} color="text.secondary">
-                    {(group.members || []).length} members
-                  </Typography>
-                </Stack>
+            filtered.map((group) => {
+              const memberCount = (group.members || []).length;
 
+              return (
                 <Box
+                  key={group.id}
+                  onClick={() => handleGroupClick(group)}
                   sx={{
-                    width: 70,
-                    height: 40,
-                    bgcolor: "#c4c4c4",
-                    borderRadius: 1,
-                    backgroundImage: group.avatar ? `url(${group.avatar})` : "",
-                    backgroundSize: "cover",
-                    backgroundPosition: "center",
+                    px: 2,
+                    py: 1.5,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    borderBottom: "1px solid #d0d0d0",
+                    cursor: "pointer",
                   }}
-                />
-              </Box>
-            ))}
-        </Box>
+                >
+                  <Stack spacing={0.3}>
+                    <Typography fontWeight={700} fontSize={14}>
+                      {group.name}
+                    </Typography>
+                    <Typography fontSize={12} color="text.secondary">
+                      {memberCount} {memberCount === 1 ? "member" : "members"}
+                    </Typography>
+                  </Stack>
 
-        <Box
-          sx={{
-            bgcolor: "#000",
-            p: 1,
-            display: "flex",
-            justifyContent: "center",
-          }}
-        >
-          <Button
-            onClick={() => setOpenCreate(true)}
-            sx={{
-              minWidth: 100,
-              height: 40,
-              borderRadius: 2,
-              bgcolor: "#FFD100",
-              color: "#000",
-              fontWeight: 700,
-              textTransform: "none",
-              "&:hover": { bgcolor: "#ffde33" },
-            }}
-          >
-            + New Group
-          </Button>
+                  <Box
+                    sx={{
+                      width: 70,
+                      height: 40,
+                      bgcolor: "#c4c4c4",
+                      borderRadius: 1,
+                      backgroundImage: group.avatar
+                        ? `url(${group.avatar})`
+                        : "",
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                    }}
+                  />
+                </Box>
+              );
+            })}
         </Box>
       </Box>
-
-      {openCreate && (
-        <Box
-          sx={{
-            position: "fixed",
-            inset: 0,
-            bgcolor: "rgba(0,0,0,0.6)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            p: 2,
-            zIndex: 1300,
-          }}
-        >
-          <Box sx={{ width: "100%", maxWidth: 520 }}>
-            <GroupCreationForm onClose={() => setOpenCreate(false)} />
-          </Box>
-        </Box>
-      )}
     </Box>
   );
 };

--- a/src/pages/Groups/Groups.jsx
+++ b/src/pages/Groups/Groups.jsx
@@ -1,13 +1,21 @@
 import { Box, Typography } from "@mui/material";
 import GroupCreationForm from "./GroupCreationForm";
 import GroupDisplay from "./GroupDisplay";
+import { useSneakerMember } from "../../context/MemberContext";
 
 const GroupsPage = () => {
+  const { member, loading, error } = useSneakerMember();
+
   return (
-    <Box sx={{  pt: 4 }}>
+    <Box sx={{ pt: 4 }}>
       <Typography
         variant="h1"
-        sx={{ color: "#FFD100", fontWeight: "bold", mb: 4, textAlign: "center" }}
+        sx={{
+          color: "#FFD100",
+          fontWeight: "bold",
+          mb: 4,
+          textAlign: "center",
+        }}
       >
         Groups
       </Typography>
@@ -21,8 +29,9 @@ const GroupsPage = () => {
         <Box sx={{ maxWidth: 700, width: "100%" }}>
           <GroupCreationForm />
         </Box>
-           <Box sx={{ maxWidth: 700, width: "100%" }}>
-          <GroupDisplay />
+
+        <Box sx={{ maxWidth: 700, width: "100%" }}>
+          <GroupDisplay currentUserId={member?.id} />
         </Box>
       </Box>
     </Box>

--- a/src/pages/Groups/Groups.jsx
+++ b/src/pages/Groups/Groups.jsx
@@ -4,7 +4,7 @@ import GroupDisplay from "./GroupDisplay";
 import { useSneakerMember } from "../../context/MemberContext";
 
 const GroupsPage = () => {
-  const { member, loading, error } = useSneakerMember();
+  const { member, loading } = useSneakerMember();
 
   return (
     <Box sx={{ pt: 4 }}>
@@ -31,7 +31,10 @@ const GroupsPage = () => {
         </Box>
 
         <Box sx={{ maxWidth: 700, width: "100%" }}>
-          <GroupDisplay currentUserId={member?.id} />
+          <GroupDisplay
+            currentUserId={member?.id}
+            currentUserLoading={loading}
+          />
         </Box>
       </Box>
     </Box>

--- a/src/pages/Groups/Groups.jsx
+++ b/src/pages/Groups/Groups.jsx
@@ -7,9 +7,16 @@ const GroupsPage = () => {
   const { member, loading } = useSneakerMember();
 
   return (
-    <Box sx={{ pt: 4 }}>
+    <Box
+      sx={{
+        px: { xs: 2, md: 4 },
+        py: 4,
+        bgcolor: "#000",
+        minHeight: "100vh",
+      }}
+    >
       <Typography
-        variant="h1"
+        variant="h3"
         sx={{
           color: "#FFD100",
           fontWeight: "bold",
@@ -22,20 +29,17 @@ const GroupsPage = () => {
 
       <Box
         sx={{
-          display: "flex",
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", lg: "1.2fr 1fr" },
+          gap: 4,
           alignItems: "flex-start",
+          maxWidth: 1400,
+          mx: "auto",
         }}
       >
-        <Box sx={{ maxWidth: 700, width: "100%" }}>
-          <GroupCreationForm />
-        </Box>
+        <GroupCreationForm />
 
-        <Box sx={{ maxWidth: 700, width: "100%" }}>
-          <GroupDisplay
-            currentUserId={member?.id}
-            currentUserLoading={loading}
-          />
-        </Box>
+        <GroupDisplay currentUserId={member?.id} currentUserLoading={loading} />
       </Box>
     </Box>
   );

--- a/src/pages/Groups/Groups.jsx
+++ b/src/pages/Groups/Groups.jsx
@@ -1,5 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import GroupCreationForm from "./GroupCreationForm";
+import GroupDisplay from "./GroupDisplay";
 
 const GroupsPage = () => {
   return (
@@ -19,6 +20,9 @@ const GroupsPage = () => {
       >
         <Box sx={{ maxWidth: 700, width: "100%" }}>
           <GroupCreationForm />
+        </Box>
+           <Box sx={{ maxWidth: 700, width: "100%" }}>
+          <GroupDisplay />
         </Box>
       </Box>
     </Box>

--- a/src/routes/MemberRoutes.jsx
+++ b/src/routes/MemberRoutes.jsx
@@ -11,6 +11,7 @@ import { ChatDashboardMember } from "../pages/Chats/ChatDashboardMember";
 import { GenerateMember } from "../pages/GenerateMember/GenerateMember";
 import { OnboardMember } from "../pages/OnboardMember/OnboardMember";
 import GroupsPage from "../pages/Groups/Groups";
+import NewGroupPage from "../pages/GroupsPage/NewGroupPage";
 
 const MemberRoutes = () => {
   return (
@@ -66,10 +67,19 @@ const MemberRoutes = () => {
             </Layout>
           }
         />
-        <Route path="groups" 
+        <Route
+          path="groups"
           element={
             <Layout>
               <GroupsPage />
+            </Layout>
+          }
+        />
+        <Route
+          path="groups/:id"
+          element={
+            <Layout>
+              <NewGroupPage />
             </Layout>
           }
         />


### PR DESCRIPTION
Changes
Extract GroupCreationForm into a standalone left-side card with:

Group name, description, avatar upload, and member search

Debounced member lookup and add/remove member controls

Reset/Cancel behavior and cleaned-up state management

Extract GroupDisplay into a standalone right-side card with:

“Trending Groups” and “My Groups” tab toggle

Search input to filter groups by name

Clickable group rows that navigate to the group detail route

Update GroupsPage to:

Use a responsive two-column grid layout (stacked on mobile)

Delegate all form and list logic to the child components

Minor styling updates to better match the Sneaker Society visual design (colors, spacing, shadows)