### PR TITLE
Build Discover / My Society tab switcher and layout shell

### DIFF
--- a/src/pages/Society/DiscoverFeed.jsx
+++ b/src/pages/Society/DiscoverFeed.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Box, Typography, Skeleton } from "@mui/material";
+import { ExploreOutlined } from "@mui/icons-material";
+import { useColors } from "../../theme/colors";
+
+// Layout shell for the Discover tab.
+// Data fetching (GraphQL accounts, follow/unfollow) is wired up in follow-up tickets.
+
+const AccountCardSkeleton = () => (
+  <Box
+    sx={{
+      display: "flex",
+      alignItems: "center",
+      gap: 2,
+      p: 2,
+      borderRadius: "16px",
+      backgroundColor: "#D9D9D9",
+      mb: 2,
+    }}
+  >
+    <Skeleton variant="circular" width={48} height={48} />
+    <Box sx={{ flex: 1 }}>
+      <Skeleton variant="text" width="40%" height={20} />
+      <Skeleton variant="text" width="70%" height={16} />
+    </Box>
+    <Skeleton variant="rounded" width={80} height={34} sx={{ borderRadius: "20px" }} />
+  </Box>
+);
+
+const DiscoverFeed = () => {
+  const colors = useColors();
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Typography
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontWeight: 600,
+          fontSize: { xs: "1.3rem", sm: "1.6rem" },
+          color: colors.textPrimary,
+          mb: 1,
+        }}
+      >
+        Recommended Accounts
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontSize: "0.9rem",
+          color: colors.textSecondary,
+          mb: 3,
+        }}
+      >
+        Discover members and creators in the Sneaker Society community.
+      </Typography>
+
+      {/* Skeleton placeholders — replaced by real data in the GraphQL fetch ticket */}
+      {[...Array(4)].map((_, i) => (
+        <AccountCardSkeleton key={i} />
+      ))}
+
+      {/* Empty state icon — visible once real data loads and returns empty */}
+      <Box
+        sx={{
+          display: "none", // toggled on when data is empty
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          py: 8,
+          gap: 2,
+        }}
+        id="discover-empty-state"
+      >
+        <ExploreOutlined sx={{ fontSize: 64, color: colors.textSecondary, opacity: 0.5 }} />
+        <Typography
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            color: colors.textSecondary,
+            fontSize: "1rem",
+            textAlign: "center",
+          }}
+        >
+          No accounts to discover yet. Check back soon!
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default DiscoverFeed;

--- a/src/pages/Society/MySocietyFeed.jsx
+++ b/src/pages/Society/MySocietyFeed.jsx
@@ -1,0 +1,211 @@
+import React, { useState } from "react";
+import { Box, Typography, Button } from "@mui/material";
+import { useColors } from "../../theme/colors";
+
+// Placeholder posts — will be replaced by real GraphQL data in a follow-up ticket
+const PLACEHOLDER_POSTS = [
+  {
+    id: 1,
+    username: "Username",
+    caption: "Just got some new kicks to customize! Can't wait to show the after!",
+    images: [
+      "https://images.unsplash.com/photo-1549298916-b41d501d3772?w=300&h=300&fit=crop",
+      "https://images.unsplash.com/photo-1556906781-9a412961c28c?w=300&h=300&fit=crop",
+    ],
+    likes: 20,
+    comments: 10,
+    shares: 11,
+  },
+  {
+    id: 2,
+    username: "Username",
+    caption: "Just got some new kicks to customize! Can't wait to show the after!",
+    images: [
+      "https://images.unsplash.com/photo-1549298916-b41d501d3772?w=300&h=300&fit=crop",
+      "https://images.unsplash.com/photo-1556906781-9a412961c28c?w=300&h=300&fit=crop",
+    ],
+    likes: 20,
+    comments: 10,
+    shares: 11,
+  },
+];
+
+const PostCard = ({ post, onLike, onComment, onShare }) => {
+  const colors = useColors();
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        backgroundColor: "#D9D9D9",
+        borderRadius: { xs: "20px", sm: "28px" },
+        padding: { xs: 2, sm: 3 },
+        mb: { xs: 3, sm: 4 },
+      }}
+    >
+      {/* User info */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 2 }}>
+        <Box
+          sx={{
+            width: { xs: 32, sm: 40 },
+            height: { xs: 32, sm: 40 },
+            backgroundColor: "#000",
+            borderRadius: "50%",
+            flexShrink: 0,
+          }}
+        />
+        <Typography
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 400,
+            fontSize: { xs: "14px", sm: "15px" },
+            color: "#000",
+          }}
+        >
+          {post.username}
+        </Typography>
+      </Box>
+
+      {/* Caption */}
+      <Typography
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontSize: { xs: "14px", sm: "15px" },
+          color: "#000",
+          mb: 3,
+          wordWrap: "break-word",
+        }}
+      >
+        {post.caption}
+      </Typography>
+
+      {/* Images */}
+      <Box sx={{ display: "flex", gap: 2, mb: 3, justifyContent: "center" }}>
+        {post.images.map((src, i) => (
+          <Box
+            key={i}
+            component="img"
+            src={src}
+            alt={`Post image ${i + 1}`}
+            sx={{
+              width: "45%",
+              height: { xs: "120px", sm: "150px" },
+              objectFit: "cover",
+              borderRadius: "10px",
+              border: "2px solid #e0e0e0",
+            }}
+          />
+        ))}
+      </Box>
+
+      {/* Stats */}
+      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 2, flexWrap: "wrap", gap: 1 }}>
+        {[`${post.likes} likes`, `${post.comments} comments`, `${post.shares} shares`].map((stat) => (
+          <Typography
+            key={stat}
+            sx={{ fontFamily: "Montserrat, sans-serif", fontSize: "12px", color: "#000" }}
+          >
+            {stat}
+          </Typography>
+        ))}
+      </Box>
+
+      <Box sx={{ height: "2px", backgroundColor: "#000", mb: 2 }} />
+
+      {/* Actions */}
+      <Box sx={{ display: "flex", justifyContent: "space-around" }}>
+        {[
+          { label: "Like", handler: () => onLike(post.id) },
+          { label: "Comment", handler: () => onComment(post.id) },
+          { label: "Share", handler: () => onShare(post.id) },
+        ].map(({ label, handler }) => (
+          <Button
+            key={label}
+            onClick={handler}
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontSize: { xs: "14px", sm: "15px" },
+              color: "#000",
+              textTransform: "none",
+              "&:hover": { backgroundColor: "rgba(0,0,0,0.08)" },
+            }}
+          >
+            {label}
+          </Button>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+const MySocietyFeed = () => {
+  const [posts, setPosts] = useState(PLACEHOLDER_POSTS);
+
+  const handleLike = (postId) =>
+    setPosts((prev) =>
+      prev.map((p) => (p.id === postId ? { ...p, likes: p.likes + 1 } : p))
+    );
+
+  const handleComment = (postId) => console.log("Comment on post:", postId);
+  const handleShare = (postId) => console.log("Share post:", postId);
+
+  const handleCreatePost = () => console.log("Create new post");
+
+  return (
+    <>
+      <Typography
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontWeight: 600,
+          fontSize: { xs: "1.3rem", sm: "1.6rem" },
+          color: "#fff",
+          mb: 3,
+        }}
+      >
+        My Posts
+      </Typography>
+
+      {posts.map((post) => (
+        <PostCard
+          key={post.id}
+          post={post}
+          onLike={handleLike}
+          onComment={handleComment}
+          onShare={handleShare}
+        />
+      ))}
+
+      {/* Create Post FAB */}
+      <Box
+        sx={{
+          position: "fixed",
+          bottom: { xs: 20, sm: 32 },
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 1000,
+        }}
+      >
+        <Button
+          onClick={handleCreatePost}
+          sx={{
+            backgroundColor: "#FFD100",
+            borderRadius: "30px",
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 800,
+            fontSize: { xs: "15px", sm: "17px" },
+            color: "#000",
+            textTransform: "none",
+            px: { xs: 3, sm: 4 },
+            py: 1.5,
+            boxShadow: "0px 4px 12px rgba(0,0,0,0.25)",
+            "&:hover": { backgroundColor: "#E6BC00" },
+          }}
+        >
+          Create Post
+        </Button>
+      </Box>
+    </>
+  );
+};
+
+export default MySocietyFeed;

--- a/src/pages/Society/SocietyPage.jsx
+++ b/src/pages/Society/SocietyPage.jsx
@@ -1,0 +1,136 @@
+import React, { useState, useRef, useCallback } from "react";
+import { Box, Typography, Button } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import { useColors } from "../../theme/colors";
+import MySocietyFeed from "./MySocietyFeed";
+import DiscoverFeed from "./DiscoverFeed";
+
+const TABS = [
+  { key: "my-society", label: "My Society" },
+  { key: "discover", label: "Discover" },
+];
+
+const SocietyPage = ({ defaultTab = "my-society" }) => {
+  const colors = useColors();
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState(defaultTab);
+
+  // Preserve scroll position per tab
+  const scrollPositions = useRef({ "my-society": 0, discover: 0 });
+  const scrollContainerRef = useRef(null);
+
+  const handleTabSwitch = useCallback(
+    (tabKey) => {
+      if (tabKey === activeTab) return;
+
+      // Save current scroll position
+      if (scrollContainerRef.current) {
+        scrollPositions.current[activeTab] = scrollContainerRef.current.scrollTop;
+      }
+
+      setActiveTab(tabKey);
+      navigate(`/member/${tabKey}`, { replace: true });
+
+      // Restore scroll position for the new tab on next render
+      requestAnimationFrame(() => {
+        if (scrollContainerRef.current) {
+          scrollContainerRef.current.scrollTop =
+            scrollPositions.current[tabKey] || 0;
+        }
+      });
+    },
+    [activeTab, navigate]
+  );
+
+  return (
+    <Box
+      ref={scrollContainerRef}
+      sx={{
+        width: "100%",
+        minHeight: "100vh",
+        backgroundColor: colors.isDark ? "#000" : "#fff",
+        overflowY: "auto",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: { xs: "100%", sm: "600px", md: "750px" },
+          px: { xs: 2, sm: 3 },
+          pt: { xs: 4, sm: 5 },
+          pb: 2,
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 700,
+            fontSize: { xs: "2rem", sm: "2.8rem", md: "3.2rem" },
+            color: "#FFD100",
+            mb: 3,
+          }}
+        >
+          Society
+        </Typography>
+
+        {/* Tab Switcher */}
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1,
+            borderBottom: `2px solid ${colors.isDark ? "#222" : "#e0e0e0"}`,
+            mb: 3,
+          }}
+        >
+          {TABS.map((tab) => {
+            const isActive = activeTab === tab.key;
+            return (
+              <Button
+                key={tab.key}
+                onClick={() => handleTabSwitch(tab.key)}
+                disableRipple={isActive}
+                sx={{
+                  fontFamily: "Montserrat, sans-serif",
+                  fontWeight: 600,
+                  fontSize: { xs: "0.9rem", sm: "1rem" },
+                  textTransform: "none",
+                  color: isActive ? "#FFD100" : colors.textSecondary,
+                  borderBottom: isActive ? "3px solid #FFD100" : "3px solid transparent",
+                  borderRadius: 0,
+                  mb: "-2px",
+                  px: 2,
+                  pb: 1,
+                  "&:hover": {
+                    backgroundColor: "transparent",
+                    color: isActive ? "#FFD100" : colors.textPrimary,
+                  },
+                }}
+              >
+                {tab.label}
+              </Button>
+            );
+          })}
+        </Box>
+      </Box>
+
+      {/* Tab Content */}
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: { xs: "100%", sm: "600px", md: "750px" },
+          px: { xs: 2, sm: 3 },
+          pb: 10,
+        }}
+      >
+        {activeTab === "my-society" && <MySocietyFeed />}
+        {activeTab === "discover" && <DiscoverFeed />}
+      </Box>
+    </Box>
+  );
+};
+
+export default SocietyPage;

--- a/src/routes/MemberRoutes.jsx
+++ b/src/routes/MemberRoutes.jsx
@@ -12,8 +12,7 @@ import { GenerateMember } from "../pages/GenerateMember/GenerateMember";
 import { OnboardMember } from "../pages/OnboardMember/OnboardMember";
 import GroupsPage from "../pages/Groups/Groups";
 import NewGroupPage from "../pages/GroupsPage/NewGroupPage";
-import MySociety from "../pages/Dashboard/MySociety";
-import Discover from "../pages/Dashboard/Discover";
+import SocietyPage from "../pages/Society/SocietyPage";
 import TheVault from "../pages/Vault/TheVault";
 import ChatSidebar from "../pages/Chats/ChatSidebar";
 import MemberSettings from "../pages/membersettings";
@@ -92,7 +91,7 @@ const MemberRoutes = () => {
           path="my-society"
           element={
             <Layout>
-              <MySociety />
+              <SocietyPage defaultTab="my-society" />
             </Layout>
           }
         />
@@ -100,7 +99,7 @@ const MemberRoutes = () => {
           path="discover"
           element={
             <Layout>
-              <Discover />
+              <SocietyPage defaultTab="discover" />
             </Layout>
           }
         />


### PR DESCRIPTION
## Summary
- Unified `SocietyPage` with a **My Society** / **Discover** tab switcher
- Switching tabs updates the URL (`/member/my-society` ↔ `/member/discover`) and restores each tab's scroll position independently
- `MySocietyFeed` — post feed with like/comment/share handlers and a fixed Create Post FAB (placeholder data, real GraphQL in follow-up)
- `DiscoverFeed` — layout shell with header, skeleton account cards, and an empty state ready for GraphQL wiring
- Both routes in `MemberRoutes` now render `SocietyPage` with the correct `defaultTab`

## Test plan
- [ ] Clicking "My Society" in sidebar lands on My Society tab
- [ ] Clicking "Discover" in sidebar lands on Discover tab
- [ ] Switching tabs via the switcher updates the URL
- [ ] Scroll position is preserved when switching back and forth between tabs
- [ ] Create Post FAB visible on My Society tab
- [ ] Discover tab shows skeleton cards layout shell

Trello: https://trello.com/c/UAp219pc