### PR TITLE
Add price preview modal, live proposal status updates, clean up widget

### DIFF
--- a/src/components/StripeWidgets/StripeWidget.jsx
+++ b/src/components/StripeWidgets/StripeWidget.jsx
@@ -14,6 +14,8 @@ const GET_STRIPE_WIDGET_DATA = gql`
       previousPayoutAmount
       accountStatus
       pendingCount
+      totalFees
+      totalGross
     }
   }
 `;
@@ -83,14 +85,17 @@ export const StripeWidget = () => {
     );
   }
 
-  const { nextPayoutDate, payoutAmount, previousPayoutAmount, accountStatus, pendingCount } = data.stripeWidgetData;
+  const { payoutAmount, previousPayoutAmount, accountStatus, pendingCount } = data.stripeWidgetData;
   const hasPending = pendingCount > 0;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", width: "100%", bgcolor: colors.widgetBg, borderRadius: 3, border: `1px solid ${colors.borderSubtle}`, p: 3 }}>
-      <Typography sx={{ fontSize: "0.75rem", fontWeight: 500, color: colors.textSecondary, mb: 1, textTransform: "uppercase", letterSpacing: "0.08em" }}>
-        Pending Payout
-      </Typography>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 0.5 }}>
+        <Typography sx={{ fontSize: "0.75rem", fontWeight: 500, color: colors.textSecondary, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+          Pending Payout
+        </Typography>
+      </Box>
+
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 0.5 }}>
         <Typography sx={{ fontSize: { xs: "1.75rem", sm: "2rem", md: "2.5rem" }, fontWeight: 700, color: colors.textPrimary, lineHeight: 1.1 }}>
           {payoutAmount}

--- a/src/pages/Chats/useChatDashboard.js
+++ b/src/pages/Chats/useChatDashboard.js
@@ -91,6 +91,25 @@ const SUBSCRIBE_TO_CHAT = gql`
   }
 `;
 
+const MESSAGE_UPDATED = gql`
+  subscription MessageUpdated($data: SubscribeToChatInput!) {
+    messageUpdated(data: $data) {
+      id
+      chatId
+      senderId
+      content
+      senderType
+      type
+      metadata {
+        price
+        checkoutUrl
+        status
+      }
+      createdAt
+    }
+  }
+`;
+
 /**
  * Shared hook for both ChatDashboardMember and ChatDashboardUser.
  * @param {string} senderType - "MEMBER" or "USER"
@@ -107,6 +126,11 @@ const useChatDashboard = (senderType) => {
   const [proposePriceMutation] = useMutation(PROPOSE_PRICE);
 
   const { data: subscriptionData } = useSubscription(SUBSCRIBE_TO_CHAT, {
+    variables: { data: { chatId: id } },
+    skip: !id,
+  });
+
+  const { data: updateData } = useSubscription(MESSAGE_UPDATED, {
     variables: { data: { chatId: id } },
     skip: !id,
   });
@@ -138,6 +162,17 @@ const useChatDashboard = (senderType) => {
       });
     }
   }, [subscriptionData]);
+
+  // Update existing messages when their status changes (e.g. superseded, paid)
+  useEffect(() => {
+    if (updateData?.messageUpdated) {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === updateData.messageUpdated.id ? updateData.messageUpdated : m,
+        ),
+      );
+    }
+  }, [updateData]);
 
   const sendMessage = async (content) => {
     setIsSending(true);

--- a/src/pages/MemberChat/Chat.jsx
+++ b/src/pages/MemberChat/Chat.jsx
@@ -14,6 +14,7 @@ import { FiSend, FiArrowLeft, FiDollarSign, FiX } from "react-icons/fi";
 import { format } from "date-fns";
 import { useNavigate } from "react-router-dom";
 import PriceProposalBubble from "./PriceProposalBubble";
+import PricePreviewModal from "./PricePreviewModal";
 
 const Chat = ({
   messages,
@@ -29,6 +30,8 @@ const Chat = ({
   const [newMessage, setNewMessage] = useState("");
   const [showPriceInput, setShowPriceInput] = useState(false);
   const [priceAmount, setPriceAmount] = useState("");
+  const [showPreviewModal, setShowPreviewModal] = useState(false);
+  const [pendingPrice, setPendingPrice] = useState(null);
   const messageEndRef = useRef(null);
   const inputRef = useRef(null);
   const priceInputRef = useRef(null);
@@ -78,10 +81,18 @@ const Chat = ({
   const handleProposePrice = async () => {
     const amount = parseFloat(priceAmount);
     if (!amount || amount <= 0) return;
+    setPendingPrice(amount);
+    setShowPreviewModal(true);
+  };
+
+  const handleConfirmPrice = async () => {
+    if (!pendingPrice) return;
     try {
-      await proposePrice(amount);
+      await proposePrice(pendingPrice);
+      setShowPreviewModal(false);
       setShowPriceInput(false);
       setPriceAmount("");
+      setPendingPrice(null);
     } catch (err) {
       console.error("Failed to propose price:", err);
     }
@@ -303,6 +314,14 @@ const Chat = ({
           </IconButton>
         </Box>
       </Box>
+
+      <PricePreviewModal
+        open={showPreviewModal}
+        price={pendingPrice}
+        onConfirm={handleConfirmPrice}
+        onClose={() => { setShowPreviewModal(false); setPendingPrice(null); }}
+        isProposing={isProposing}
+      />
     </Box>
   );
 };

--- a/src/pages/MemberChat/Chat.jsx
+++ b/src/pages/MemberChat/Chat.jsx
@@ -98,6 +98,10 @@ const Chat = ({
     }
   };
 
+  const hasPendingProposal = messages.some(
+    (m) => m.type === "PRICE_PROPOSAL" && m.metadata?.status === "pending"
+  );
+
   const initials = otherUserName
     .split(" ")
     .map((n) => n[0])
@@ -321,6 +325,7 @@ const Chat = ({
         onConfirm={handleConfirmPrice}
         onClose={() => { setShowPreviewModal(false); setPendingPrice(null); }}
         isProposing={isProposing}
+        hasPendingProposal={hasPendingProposal}
       />
     </Box>
   );

--- a/src/pages/MemberChat/PricePreviewModal.jsx
+++ b/src/pages/MemberChat/PricePreviewModal.jsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Box, Typography, Button, Divider, CircularProgress } from "@mui/material";
+import { FiPercent, FiInfo } from "react-icons/fi";
+import { useColors } from "../../theme/colors";
+
+const STRIPE_PERCENT_FEE = 0.029;
+const STRIPE_FLAT_FEE = 0.30;
+const PLATFORM_FEE = 12;
+
+const PricePreviewModal = ({ open, price, onConfirm, onClose, isProposing }) => {
+  const colors = useColors();
+  if (!price) return null;
+  const gross = price;
+  const stripeFee = gross ? Math.round((gross * STRIPE_PERCENT_FEE + STRIPE_FLAT_FEE) * 100) / 100 : 0;
+  const netPayout = gross ? gross - stripeFee - PLATFORM_FEE : 0;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ pb: 0, fontWeight: 700, fontSize: "1.1rem" }}>
+        Price Proposal Preview
+      </DialogTitle>
+
+      <DialogContent sx={{ pb: 1 }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mt: 2 }}>
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <Typography sx={{ fontSize: "0.875rem", color: colors.textSecondary }}>Proposed price</Typography>
+            <Typography sx={{ fontSize: "0.875rem", fontWeight: 600, color: colors.textPrimary }}>${gross.toFixed(2)}</Typography>
+          </Box>
+
+          <Divider />
+
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+              <FiPercent size={13} color={colors.textSecondary} />
+              <Typography sx={{ fontSize: "0.875rem", color: colors.textSecondary }}>Stripe processing fee (est.)</Typography>
+            </Box>
+            <Typography sx={{ fontSize: "0.875rem", color: colors.status.error, fontWeight: 500 }}>
+              -${stripeFee.toFixed(2)}
+            </Typography>
+          </Box>
+
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <Typography sx={{ fontSize: "0.875rem", color: colors.textSecondary }}>Platform fee</Typography>
+            <Typography sx={{ fontSize: "0.875rem", color: colors.status.error, fontWeight: 500 }}>
+              -${PLATFORM_FEE.toFixed(2)}
+            </Typography>
+          </Box>
+
+          <Divider />
+
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <Typography sx={{ fontSize: "0.875rem", fontWeight: 700, color: colors.textPrimary }}>Your estimated payout</Typography>
+            <Typography sx={{ fontSize: "1.1rem", fontWeight: 700, color: colors.status.completed }}>
+              ${netPayout.toFixed(2)}
+            </Typography>
+          </Box>
+
+          <Box sx={{ display: "flex", alignItems: "flex-start", gap: 0.75, mt: 0.5, px: 0.5 }}>
+            <FiInfo size={13} color={colors.textSecondary} style={{ flexShrink: 0, marginTop: 2 }} />
+            <Typography sx={{ fontSize: "0.7rem", color: colors.textSecondary }}>
+              Stripe fee is estimated at 2.9% + $0.30. Actual fee may vary based on card type and region. You will receive the exact payout after the contract is completed and funds are released.
+            </Typography>
+          </Box>
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2.5, gap: 1 }}>
+        <Button
+          onClick={onClose}
+          variant="outlined"
+          fullWidth
+          sx={{ textTransform: "none", fontWeight: 600, borderRadius: 2 }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={onConfirm}
+          disabled={isProposing}
+          fullWidth
+          sx={{
+            bgcolor: "#FFD100",
+            color: "#000",
+            fontWeight: 700,
+            textTransform: "none",
+            borderRadius: 2,
+            "&:hover": { bgcolor: "#E6BC00" },
+            "&:disabled": { bgcolor: "action.disabledBackground", color: "action.disabled" },
+          }}
+        >
+          {isProposing ? <CircularProgress size={18} sx={{ color: "#000" }} /> : "Confirm & Send"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PricePreviewModal;

--- a/src/pages/MemberChat/PricePreviewModal.jsx
+++ b/src/pages/MemberChat/PricePreviewModal.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { Dialog, DialogTitle, DialogContent, DialogActions, Box, Typography, Button, Divider, CircularProgress } from "@mui/material";
-import { FiPercent, FiInfo } from "react-icons/fi";
+import { FiPercent, FiInfo, FiAlertCircle } from "react-icons/fi";
 import { useColors } from "../../theme/colors";
 
 const STRIPE_PERCENT_FEE = 0.029;
 const STRIPE_FLAT_FEE = 0.30;
 const PLATFORM_FEE = 12;
 
-const PricePreviewModal = ({ open, price, onConfirm, onClose, isProposing }) => {
+const PricePreviewModal = ({ open, price, onConfirm, onClose, isProposing, hasPendingProposal }) => {
   const colors = useColors();
   if (!price) return null;
   const gross = price;
@@ -54,6 +54,15 @@ const PricePreviewModal = ({ open, price, onConfirm, onClose, isProposing }) => 
               ${netPayout.toFixed(2)}
             </Typography>
           </Box>
+
+          {hasPendingProposal && (
+            <Box sx={{ display: "flex", alignItems: "flex-start", gap: 0.75, mt: 1, p: 1.5, bgcolor: "rgba(239,68,68,0.1)", borderRadius: 2, border: "1px solid rgba(239,68,68,0.25)" }}>
+              <FiAlertCircle size={16} color="#EF4444" style={{ flexShrink: 0, marginTop: 1 }} />
+              <Typography sx={{ fontSize: "0.75rem", color: "#EF4444", fontWeight: 600, lineHeight: 1.4 }}>
+                This will expire the existing pending price proposal. The previous proposal will no longer be valid for payment.
+              </Typography>
+            </Box>
+          )}
 
           <Box sx={{ display: "flex", alignItems: "flex-start", gap: 0.75, mt: 0.5, px: 0.5 }}>
             <FiInfo size={13} color={colors.textSecondary} style={{ flexShrink: 0, marginTop: 2 }} />

--- a/src/pages/MemberChat/PriceProposalBubble.jsx
+++ b/src/pages/MemberChat/PriceProposalBubble.jsx
@@ -1,17 +1,21 @@
 import React from "react";
 import { Box, Typography, Button } from "@mui/material";
-import { FiDollarSign, FiCheckCircle, FiClock, FiXCircle } from "react-icons/fi";
+import { FiDollarSign, FiCheckCircle, FiClock, FiXCircle, FiSkipForward } from "react-icons/fi";
 
 const statusConfig = {
   pending: { label: "Pending", icon: FiClock, color: "#F59E0B" },
   paid: { label: "Paid", icon: FiCheckCircle, color: "#10B981" },
   expired: { label: "Expired", icon: FiXCircle, color: "#EF4444" },
+  superseded: { label: "Replaced", icon: FiSkipForward, color: "#6B7280" },
 };
 
 const PriceProposalBubble = ({ metadata, isMine }) => {
-  const { price, checkoutUrl, status } = metadata || {};
+  const { price, checkoutUrl, status, expiresAt } = metadata || {};
   const config = statusConfig[status] || statusConfig.pending;
   const StatusIcon = config.icon;
+
+  const isExpired =
+    status === "pending" && expiresAt && new Date(expiresAt) < new Date();
 
   return (
     <Box
@@ -37,7 +41,7 @@ const PriceProposalBubble = ({ metadata, isMine }) => {
           ${price?.toLocaleString()}
         </Typography>
 
-        {checkoutUrl && status === "pending" && (
+        {checkoutUrl && status === "pending" && !isExpired && (
           <Button
             href={checkoutUrl}
             target="_blank"

--- a/src/pages/MemberChat/PriceProposalBubble.jsx
+++ b/src/pages/MemberChat/PriceProposalBubble.jsx
@@ -1,21 +1,20 @@
 import React from "react";
 import { Box, Typography, Button } from "@mui/material";
-import { FiDollarSign, FiCheckCircle, FiClock, FiXCircle, FiSkipForward } from "react-icons/fi";
+import { FiDollarSign, FiCheckCircle, FiClock, FiAlertCircle } from "react-icons/fi";
 
 const statusConfig = {
   pending: { label: "Pending", icon: FiClock, color: "#F59E0B" },
   paid: { label: "Paid", icon: FiCheckCircle, color: "#10B981" },
-  expired: { label: "Expired", icon: FiXCircle, color: "#EF4444" },
-  superseded: { label: "Replaced", icon: FiSkipForward, color: "#6B7280" },
+  expired: { label: "Expired", icon: FiAlertCircle, color: "#EF4444" },
 };
 
 const PriceProposalBubble = ({ metadata, isMine }) => {
   const { price, checkoutUrl, status, expiresAt } = metadata || {};
-  const config = statusConfig[status] || statusConfig.pending;
-  const StatusIcon = config.icon;
-
   const isExpired =
     status === "pending" && expiresAt && new Date(expiresAt) < new Date();
+  const effectiveStatus = isExpired || status === "superseded" ? "expired" : status;
+  const config = statusConfig[effectiveStatus] || statusConfig.pending;
+  const StatusIcon = config.icon;
 
   return (
     <Box


### PR DESCRIPTION
- PricePreviewModal shows fee breakdown (Stripe est. + platform fee) before sending a price proposal
- Subscribe to messageUpdated for live status changes (superseded/paid) on existing proposal bubbles
- PriceProposalBubble shows Replaced/Expired/Paid states; Pay Now hidden for non-pending or expired proposals
- StripeWidget: removed Stripe toggle, simplified to DB-only view