### PR TITLE
Refine group page permissions and fix handler initialization errors

### DIFF
--- a/src/pages/Groups/NewGroupPage.jsx
+++ b/src/pages/Groups/NewGroupPage.jsx
@@ -28,9 +28,6 @@ const NewGroupPage = () => {
     postsError,
     currentUserLoading,
     currentUser,
-    isJoined,
-    isCreator,
-    canManageGroup,
     memberCount,
     adminIds,
     hasMorePosts,
@@ -92,6 +89,12 @@ const NewGroupPage = () => {
     openDeleteGroupModal,
     handleUpdateGroup,
     handleDeleteGroup,
+    isJoined,
+    isCreator,
+    canManageGroup,
+    canInteractWithPosts,
+    isVisitor,
+    isMemberNonAdmin,
   } = useNewGroupPage();
 
   if (loading || currentUserLoading) {
@@ -129,6 +132,16 @@ const NewGroupPage = () => {
     );
   }
 
+  const handleOpenEditGroup = () => {
+    if (!canManageGroup) return;
+    openEditGroupModal();
+  };
+
+  const handleOpenDeleteGroup = () => {
+    if (!canManageGroup) return;
+    openDeleteGroupModal();
+  };
+
   const header = (
     <GroupHeaderBanner
       group={group}
@@ -142,8 +155,8 @@ const NewGroupPage = () => {
       setIsHovering={setIsHovering}
       onJoin={handleJoinGroup}
       onOpenLeave={() => setModalOpen(true)}
-      onEditGroup={openEditGroupModal}
-      onDeleteGroup={openDeleteGroupModal}
+      onEditGroup={handleOpenEditGroup}
+      onDeleteGroup={handleOpenDeleteGroup}
     />
   );
 
@@ -216,6 +229,8 @@ const NewGroupPage = () => {
           postsLoading={postsLoading}
           postsError={postsError}
           isJoined={isJoined}
+          canInteractWithPosts={canInteractWithPosts}
+          isVisitor={isVisitor}
           isCreator={isCreator}
           joining={joining}
           currentUser={currentUser}

--- a/src/pages/Groups/PostCard.jsx
+++ b/src/pages/Groups/PostCard.jsx
@@ -35,6 +35,7 @@ const PostCard = ({
   currentUser,
   group,
   isJoined,
+  canInteractWithPosts,
   liking,
   deleting,
   commentLoading,
@@ -60,7 +61,6 @@ const PostCard = ({
   const commentCount = post.commentCount || 0;
   const visibleComments = post.commentsPage?.items || [];
   const hasMoreComments = !!post.commentsPage?.hasMore;
-
   const hasLiked = !!post.likes?.some((like) => like.id === currentUser?.id);
 
   const isPostAuthor = post.author?.id === currentUser?.id;
@@ -122,7 +122,11 @@ const PostCard = ({
 
   const likeBtnSx = {
     ...actionChipButtonSx,
-    color: !isJoined ? textSecondary : hasLiked ? accent : textSecondary,
+    color: !canInteractWithPosts
+      ? textSecondary
+      : hasLiked
+        ? accent
+        : textSecondary,
     bgcolor: hasLiked ? likeSoftBg : "transparent",
     border: hasLiked
       ? `1px solid ${likeSoftBorder}`
@@ -186,7 +190,6 @@ const PostCard = ({
     },
   };
 
-  // Image layout helpers
   const images = Array.isArray(post.images) ? post.images.slice(0, 4) : [];
   const extraImageCount = Math.max((post.images?.length || 0) - 4, 0);
 
@@ -291,7 +294,6 @@ const PostCard = ({
       );
     }
 
-    // 4+ images → 2x2 grid with overlay on last tile if there are extras
     return (
       <Box
         sx={{
@@ -393,7 +395,7 @@ const PostCard = ({
             )
           }
           onClick={onLike}
-          disabled={!isJoined || liking}
+          disabled={!canInteractWithPosts || liking}
           sx={likeBtnSx}
         >
           {hasLiked ? "Liked" : "Like"} · {likeCount}
@@ -418,7 +420,7 @@ const PostCard = ({
         </Typography>
       )}
 
-      {(visibleComments.length > 0 || isJoined) && (
+      {(visibleComments.length > 0 || canInteractWithPosts) && (
         <Box>
           <Divider sx={{ borderColor: borderSubtle, mb: 1.5 }} />
 
@@ -491,7 +493,7 @@ const PostCard = ({
             </Stack>
           )}
 
-          {isJoined ? (
+          {canInteractWithPosts ? (
             <Stack direction="row" spacing={1} alignItems="flex-start">
               <TextField
                 fullWidth

--- a/src/pages/Groups/components/GroupFeedSection.jsx
+++ b/src/pages/Groups/components/GroupFeedSection.jsx
@@ -11,6 +11,8 @@ const GroupFeedSection = ({
   postsLoading,
   postsError,
   isJoined,
+  canInteractWithPosts,
+  isVisitor,
   isCreator,
   joining,
   currentUser,
@@ -71,14 +73,18 @@ const GroupFeedSection = ({
     return (
       <StatePanel
         icon={<ForumOutlinedIcon />}
-        title={isJoined ? "No posts yet" : "This group is quiet right now"}
+        title={
+          canInteractWithPosts
+            ? "No posts yet"
+            : "This group is quiet right now"
+        }
         description={
-          isJoined
+          canInteractWithPosts
             ? "Be the first to start the conversation by sharing an update, question, or photo with the group."
             : "Join the group to take part in the conversation and see new activity as members start posting."
         }
         primaryAction={
-          isJoined ? (
+          canInteractWithPosts ? (
             <Button
               variant="contained"
               onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
@@ -117,6 +123,7 @@ const GroupFeedSection = ({
           currentUser={currentUser}
           group={group}
           isJoined={isJoined}
+          canInteractWithPosts={canInteractWithPosts}
           liking={likingPostId === post.id}
           deleting={deletingPostId === post.id}
           commentLoading={!!commentLoadingByPost[post.id]}

--- a/src/pages/Groups/components/GroupPageModals.jsx
+++ b/src/pages/Groups/components/GroupPageModals.jsx
@@ -10,6 +10,8 @@ import {
 import { useGroupPageStyles } from "../styles/groupPageStyles";
 
 const GroupPageModals = ({
+  canManageGroup = false,
+  canLeaveGroup = false,
   editModalOpen,
   setEditModalOpen,
   deleteGroupModalOpen,
@@ -41,10 +43,14 @@ const GroupPageModals = ({
     destructiveButtonSx,
   } = useGroupPageStyles();
 
+  const showEditModal = canManageGroup && editModalOpen;
+  const showDeleteGroupModal = canManageGroup && deleteGroupModalOpen;
+  const showLeaveModal = canLeaveGroup && modalOpen;
+
   return (
     <>
       <Modal
-        open={editModalOpen}
+        open={showEditModal}
         onClose={() => setEditModalOpen(false)}
         aria-labelledby="edit-group-title"
         aria-describedby="edit-group-description"
@@ -141,7 +147,7 @@ const GroupPageModals = ({
       </Modal>
 
       <Modal
-        open={deleteGroupModalOpen}
+        open={showDeleteGroupModal}
         onClose={() => setDeleteGroupModalOpen(false)}
         aria-labelledby="delete-group-title"
         aria-describedby="delete-group-description"
@@ -204,7 +210,7 @@ const GroupPageModals = ({
       </Modal>
 
       <Modal
-        open={modalOpen}
+        open={showLeaveModal}
         onClose={() => setModalOpen(false)}
         aria-labelledby="leave-group-title"
         aria-describedby="leave-group-description"

--- a/src/pages/Groups/hooks/useGroupMembership.js
+++ b/src/pages/Groups/hooks/useGroupMembership.js
@@ -35,8 +35,13 @@ export const useGroupMembership = ({ groupId, currentUser, skip }) => {
   }, [group, currentUser]);
 
   const canManageGroup = isCreator || isGroupAdmin;
+  const canInteractWithPosts = isJoined;
+  const isVisitor = !isJoined;
+  const isMemberNonAdmin = isJoined && !canManageGroup;
+
   const memberCount = group?.members?.length || 0;
   const adminCount = group?.admins?.length || 0;
+
   const adminIds = useMemo(
     () => new Set((group?.admins || []).map((admin) => admin.id)),
     [group],
@@ -77,6 +82,9 @@ export const useGroupMembership = ({ groupId, currentUser, skip }) => {
     isCreator,
     isGroupAdmin,
     canManageGroup,
+    canInteractWithPosts,
+    isVisitor,
+    isMemberNonAdmin,
     memberCount,
     adminCount,
     adminIds,


### PR DESCRIPTION
This PR tightens role-based permissions on the new group page and fixes runtime initialization errors. It ensures only joined members see and use the post composer, only authors/admins/creators can delete posts, and only group managers can open edit/delete group modals.