### PR TITLE
[Frontend] The Vault: submission dashboard, form, media upload, status cards, and admin queue

### DIFF
--- a/src/context/graphql/getVault.js
+++ b/src/context/graphql/getVault.js
@@ -1,0 +1,94 @@
+import { gql } from "@apollo/client";
+
+export const GET_VAULT_SUBMISSIONS = gql`
+  query GetVaultSubmissions {
+    vaultSubmissions {
+      id title description category platforms mediaUrls thumbnailUrl
+      status isApproved isFeatured publishedAt consentAccepted adminNotes
+      createdAt updatedAt
+      member { id firstName lastName businessName }
+    }
+  }
+`;
+
+export const GET_VAULT_SUBMISSION_BY_ID = gql`
+  query GetVaultSubmissionById($id: ID!) {
+    vaultSubmissionById(id: $id) {
+      id title description category platforms mediaUrls thumbnailUrl
+      status isApproved isFeatured publishedAt consentAccepted adminNotes
+      createdAt updatedAt
+      member { id firstName lastName businessName }
+    }
+  }
+`;
+
+export const GET_ADMIN_VAULT_QUEUE = gql`
+  query GetAdminVaultQueue($status: String, $limit: Int, $offset: Int) {
+    adminVaultQueue(status: $status, limit: $limit, offset: $offset) {
+      items {
+        id title description category platforms mediaUrls thumbnailUrl
+        status isApproved isFeatured publishedAt consentAccepted adminNotes
+        createdAt updatedAt
+        member { id firstName lastName businessName }
+      }
+      totalCount hasMore nextOffset
+    }
+  }
+`;
+
+export const CREATE_VAULT_SUBMISSION = gql`
+  mutation CreateVaultSubmission($data: CreateVaultSubmissionInput!) {
+    createVaultSubmission(data: $data) {
+      id title description category platforms mediaUrls thumbnailUrl
+      status isApproved isFeatured publishedAt consentAccepted adminNotes
+      createdAt updatedAt
+      member { id firstName lastName businessName }
+    }
+  }
+`;
+
+export const UPDATE_VAULT_SUBMISSION = gql`
+  mutation UpdateVaultSubmission($id: ID!, $data: UpdateVaultSubmissionInput!) {
+    updateVaultSubmission(id: $id, data: $data) {
+      id title description category status mediaUrls updatedAt
+    }
+  }
+`;
+
+export const DELETE_VAULT_SUBMISSION = gql`
+  mutation DeleteVaultSubmission($id: ID!) {
+    deleteVaultSubmission(id: $id)
+  }
+`;
+
+export const APPROVE_VAULT_SUBMISSION = gql`
+  mutation ApproveVaultSubmission($id: ID!, $notes: String) {
+    approveVaultSubmission(id: $id, notes: $notes) {
+      id status isApproved adminNotes
+    }
+  }
+`;
+
+export const REJECT_VAULT_SUBMISSION = gql`
+  mutation RejectVaultSubmission($id: ID!, $notes: String!) {
+    rejectVaultSubmission(id: $id, notes: $notes) {
+      id status isApproved adminNotes
+    }
+  }
+`;
+
+export const FEATURE_VAULT_SUBMISSION = gql`
+  mutation FeatureVaultSubmission($id: ID!, $featured: Boolean!) {
+    featureVaultSubmission(id: $id, featured: $featured) {
+      id isFeatured
+    }
+  }
+`;
+
+export const PUBLISH_VAULT_SUBMISSION = gql`
+  mutation PublishVaultSubmission($id: ID!) {
+    publishVaultSubmission(id: $id) {
+      id status publishedAt
+    }
+  }
+`;

--- a/src/pages/Vault/TheVault.jsx
+++ b/src/pages/Vault/TheVault.jsx
@@ -1,48 +1,367 @@
-import React from "react";
-import { Box, Typography } from "@mui/material";
-import { Inventory2Outlined } from "@mui/icons-material";
+import React, { useState } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Modal,
+  Skeleton,
+  Alert,
+  Divider,
+} from "@mui/material";
+import { Inventory2Outlined, AddOutlined } from "@mui/icons-material";
+import { useQuery } from "@apollo/client";
 import { useColors } from "../../theme/colors";
+import { useSneakerMember } from "../../context/MemberContext";
+import { GET_VAULT_SUBMISSIONS } from "../../context/graphql/getVault";
+import VaultSubmissionForm from "./VaultSubmissionForm";
+import VaultSubmissionCard from "./VaultSubmissionCard";
+import VaultAdminQueue from "./VaultAdminQueue";
+
+// Inline empty state — no submissions yet
+const VaultEmptyState = ({ onSubmit }) => {
+  const colors = useColors();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        py: { xs: 8, sm: 10 },
+        px: 2,
+        textAlign: "center",
+      }}
+    >
+      <Inventory2Outlined
+        sx={{
+          fontSize: { xs: 64, sm: 80 },
+          color: colors.warning,
+          opacity: 0.5,
+          mb: 3,
+        }}
+      />
+      <Typography
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontWeight: 700,
+          fontSize: { xs: "1.4rem", sm: "1.75rem" },
+          color: colors.textPrimary,
+          mb: 1.5,
+        }}
+      >
+        Your Vault is empty
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontSize: { xs: "14px", sm: "15px" },
+          color: colors.textSecondary,
+          maxWidth: 480,
+          lineHeight: 1.7,
+          mb: 4,
+        }}
+      >
+        Submit your best work — custom builds, merchandise drops, or content —
+        and we'll feature it across our platforms to grow your brand.
+      </Typography>
+      <Button
+        variant="contained"
+        startIcon={<AddOutlined />}
+        onClick={onSubmit}
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontWeight: 700,
+          fontSize: "15px",
+          textTransform: "none",
+          backgroundColor: colors.warning,
+          color: "#000",
+          borderRadius: "12px",
+          px: 4,
+          py: 1.5,
+          boxShadow: "0 4px 20px rgba(255,195,28,0.3)",
+          "&:hover": {
+            backgroundColor: "#e6b000",
+            boxShadow: "0 6px 24px rgba(255,195,28,0.4)",
+          },
+        }}
+      >
+        Make Your First Submission
+      </Button>
+    </Box>
+  );
+};
 
 const TheVault = () => {
   const colors = useColors();
+  const { member } = useSneakerMember();
+  const [formOpen, setFormOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState(null);
+
+  const { data, loading, error, refetch } = useQuery(GET_VAULT_SUBMISSIONS, {
+    fetchPolicy: "cache-and-network",
+  });
+
+  const submissions = data?.vaultSubmissions || [];
+  const hasSubmissions = submissions.length > 0;
+
+  const handleOpenForm = () => {
+    setEditTarget(null);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (submission) => {
+    setEditTarget(submission);
+    setFormOpen(true);
+  };
+
+  const handleFormClose = () => {
+    setFormOpen(false);
+    setEditTarget(null);
+  };
+
+  const handleSubmitted = () => {
+    handleFormClose();
+    refetch();
+  };
+
+  const modalBg = colors.isDark ? "#0d0d0d" : "#fff";
+  const borderColor = colors.isDark
+    ? "rgba(255,255,255,0.1)"
+    : "rgba(0,0,0,0.1)";
 
   return (
     <Box
       sx={{
         minHeight: "100vh",
         width: "100%",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
         backgroundColor: colors.isDark ? "#000" : "#fff",
-        gap: 3,
+        px: { xs: 2, sm: 4, md: 6 },
+        py: { xs: 4, sm: 6 },
+        boxSizing: "border-box",
       }}
     >
-      <Inventory2Outlined
-        sx={{ fontSize: 80, color: colors.warning, opacity: 0.9 }}
-      />
-      <Typography
+      {/* Page header */}
+      <Box
         sx={{
-          fontFamily: "Montserrat, sans-serif",
-          fontWeight: 700,
-          fontSize: { xs: "2rem", sm: "2.5rem", md: "3rem" },
-          color: colors.warning,
+          display: "flex",
+          alignItems: { xs: "flex-start", sm: "center" },
+          justifyContent: "space-between",
+          flexDirection: { xs: "column", sm: "row" },
+          gap: 2,
+          mb: 2,
         }}
       >
-        The Vault
-      </Typography>
-      <Typography
-        sx={{
-          color: colors.textSecondary,
-          fontSize: { xs: "1rem", sm: "1.1rem" },
-          textAlign: "center",
-          maxWidth: 400,
-          px: 2,
-        }}
-      >
-        Coming soon — your personal archive of work, history, and highlights.
-      </Typography>
+        <Box>
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontWeight: 700,
+              fontSize: { xs: "2rem", sm: "2.5rem" },
+              color: colors.warning,
+              lineHeight: 1.1,
+            }}
+          >
+            The Vault
+          </Typography>
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontSize: { xs: "13px", sm: "14px" },
+              color: colors.textSecondary,
+              mt: 0.5,
+              maxWidth: 520,
+            }}
+          >
+            Upload your custom builds, merchandise, and content for potential
+            marketing exposure across The Sneaker Society platforms.
+          </Typography>
+        </Box>
+
+        <Button
+          variant="contained"
+          startIcon={<AddOutlined />}
+          onClick={handleOpenForm}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 700,
+            fontSize: "14px",
+            textTransform: "none",
+            backgroundColor: colors.warning,
+            color: "#000",
+            borderRadius: "12px",
+            px: 3,
+            py: 1.25,
+            flexShrink: 0,
+            boxShadow: "0 4px 16px rgba(255,195,28,0.25)",
+            "&:hover": {
+              backgroundColor: "#e6b000",
+              boxShadow: "0 6px 20px rgba(255,195,28,0.35)",
+            },
+          }}
+        >
+          Submit Your Work
+        </Button>
+      </Box>
+
+      <Divider sx={{ borderColor, mb: 4 }} />
+
+      {/* Error state */}
+      {error && (
+        <Alert
+          severity="error"
+          action={
+            <Button
+              onClick={() => refetch()}
+              size="small"
+              sx={{ fontFamily: "Montserrat, sans-serif" }}
+            >
+              Retry
+            </Button>
+          }
+          sx={{
+            mb: 3,
+            fontFamily: "Montserrat, sans-serif",
+            fontSize: "14px",
+            borderRadius: "10px",
+          }}
+        >
+          Failed to load your submissions. {error.message}
+        </Alert>
+      )}
+
+      {/* Loading state */}
+      {loading && !data && (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "1fr 1fr",
+              md: "1fr 1fr 1fr",
+            },
+            gap: 2.5,
+            mb: 6,
+          }}
+        >
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Box
+              key={i}
+              sx={{
+                border: `1px solid ${borderColor}`,
+                borderRadius: "16px",
+                overflow: "hidden",
+              }}
+            >
+              <Skeleton
+                variant="rectangular"
+                height={160}
+                sx={{
+                  backgroundColor: colors.isDark
+                    ? "rgba(255,255,255,0.06)"
+                    : "rgba(0,0,0,0.06)",
+                }}
+              />
+              <Box sx={{ p: 2 }}>
+                <Skeleton
+                  variant="text"
+                  width="70%"
+                  sx={{
+                    backgroundColor: colors.isDark
+                      ? "rgba(255,255,255,0.06)"
+                      : "rgba(0,0,0,0.06)",
+                  }}
+                />
+                <Skeleton
+                  variant="text"
+                  width="40%"
+                  sx={{
+                    backgroundColor: colors.isDark
+                      ? "rgba(255,255,255,0.04)"
+                      : "rgba(0,0,0,0.04)",
+                  }}
+                />
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {/* Member submissions section */}
+      {!loading && !error && (
+        <>
+          {hasSubmissions ? (
+            <>
+              <Typography
+                sx={{
+                  fontFamily: "Montserrat, sans-serif",
+                  fontWeight: 700,
+                  fontSize: "1rem",
+                  color: colors.textSecondary,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                  mb: 2.5,
+                }}
+              >
+                Your Submissions ({submissions.length})
+              </Typography>
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: {
+                    xs: "1fr",
+                    sm: "1fr 1fr",
+                    md: "1fr 1fr 1fr",
+                  },
+                  gap: 2.5,
+                  mb: 6,
+                }}
+              >
+                {submissions.map((submission) => (
+                  <VaultSubmissionCard
+                    key={submission.id}
+                    submission={submission}
+                    onEdit={handleEdit}
+                    onDelete={() => refetch()}
+                  />
+                ))}
+              </Box>
+            </>
+          ) : (
+            <VaultEmptyState onSubmit={handleOpenForm} />
+          )}
+        </>
+      )}
+
+      {/* Admin queue */}
+      <Divider sx={{ borderColor, mb: 4 }} />
+      <VaultAdminQueue />
+
+      {/* Submission form modal */}
+      <Modal open={formOpen} onClose={handleFormClose}>
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: { xs: "95vw", sm: "600px" },
+            maxHeight: "92vh",
+            overflowY: "auto",
+            backgroundColor: modalBg,
+            border: `1px solid ${borderColor}`,
+            borderRadius: "20px",
+            boxShadow: "0 24px 80px rgba(0,0,0,0.5)",
+            p: { xs: 2.5, sm: 4 },
+          }}
+        >
+          <VaultSubmissionForm
+            onSubmitted={handleSubmitted}
+            onCancel={handleFormClose}
+            initialData={editTarget}
+          />
+        </Box>
+      </Modal>
     </Box>
   );
 };

--- a/src/pages/Vault/VaultAdminQueue.jsx
+++ b/src/pages/Vault/VaultAdminQueue.jsx
@@ -1,0 +1,704 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Typography,
+  Tabs,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Chip,
+  IconButton,
+  Button,
+  TextField,
+  Skeleton,
+  Alert,
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  CircularProgress,
+} from "@mui/material";
+import {
+  CheckCircleOutlined,
+  CancelOutlined,
+  StarOutlined,
+  StarBorderOutlined,
+  PublishOutlined,
+  VisibilityOutlined,
+} from "@mui/icons-material";
+import { useQuery, useMutation } from "@apollo/client";
+import { useColors } from "../../theme/colors";
+import {
+  GET_ADMIN_VAULT_QUEUE,
+  APPROVE_VAULT_SUBMISSION,
+  REJECT_VAULT_SUBMISSION,
+  FEATURE_VAULT_SUBMISSION,
+  PUBLISH_VAULT_SUBMISSION,
+} from "../../context/graphql/getVault";
+import VaultDetailModal from "./VaultDetailModal";
+
+const STATUS_TABS = [
+  { label: "All", value: null },
+  { label: "Pending", value: "pending" },
+  { label: "Under Review", value: "underReview" },
+  { label: "Approved", value: "approved" },
+  { label: "Rejected", value: "rejected" },
+  { label: "Published", value: "published" },
+];
+
+const STATUS_CONFIG = {
+  draft: { label: "Draft", color: "#888", bg: "rgba(136,136,136,0.15)" },
+  pending: { label: "Pending", color: "#D4AC0D", bg: "rgba(212,172,13,0.15)" },
+  underReview: { label: "Under Review", color: "#3498DB", bg: "rgba(52,152,219,0.15)" },
+  under_review: { label: "Under Review", color: "#3498DB", bg: "rgba(52,152,219,0.15)" },
+  approved: { label: "Approved", color: "#2ECC71", bg: "rgba(46,204,113,0.15)" },
+  rejected: { label: "Rejected", color: "#e74c3c", bg: "rgba(231,76,60,0.15)" },
+  published: { label: "Published", color: "#9B59B6", bg: "rgba(155,89,182,0.15)" },
+};
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return "—";
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+};
+
+const RejectDialog = ({ open, onClose, onConfirm, loading }) => {
+  const colors = useColors();
+  const [rejectNotes, setRejectNotes] = useState("");
+  const [noteError, setNoteError] = useState("");
+
+  const handleConfirm = () => {
+    if (!rejectNotes.trim()) {
+      setNoteError("Rejection notes are required.");
+      return;
+    }
+    onConfirm(rejectNotes.trim());
+  };
+
+  const handleClose = () => {
+    setRejectNotes("");
+    setNoteError("");
+    onClose();
+  };
+
+  const borderColor = colors.isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)";
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      PaperProps={{
+        sx: {
+          backgroundColor: colors.isDark ? "#111" : "#fff",
+          borderRadius: "16px",
+          border: `1px solid ${borderColor}`,
+          minWidth: 360,
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontWeight: 700,
+          color: colors.textPrimary,
+        }}
+      >
+        Reject Submission
+      </DialogTitle>
+      <DialogContent>
+        <Typography
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontSize: "13px",
+            color: colors.textSecondary,
+            mb: 2,
+          }}
+        >
+          Please provide a reason for rejection (required):
+        </Typography>
+        <TextField
+          value={rejectNotes}
+          onChange={(e) => {
+            setRejectNotes(e.target.value);
+            setNoteError("");
+          }}
+          placeholder="Rejection reason..."
+          multiline
+          rows={3}
+          fullWidth
+          error={Boolean(noteError)}
+          helperText={noteError}
+          sx={{
+            "& .MuiOutlinedInput-root": {
+              fontFamily: "Montserrat, sans-serif",
+              color: colors.textPrimary,
+              "& fieldset": { borderColor },
+            },
+          }}
+          inputProps={{ style: { fontFamily: "Montserrat, sans-serif" } }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2, gap: 1 }}>
+        <Button
+          onClick={handleClose}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            textTransform: "none",
+            color: colors.textSecondary,
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          disabled={loading}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 700,
+            textTransform: "none",
+            backgroundColor: "#e74c3c",
+            color: "#fff",
+            borderRadius: "8px",
+            px: 2,
+            "&:hover": { backgroundColor: "#c0392b" },
+          }}
+        >
+          {loading ? <CircularProgress size={16} sx={{ color: "#fff" }} /> : "Confirm Reject"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const ApproveDialog = ({ open, onClose, onConfirm, loading }) => {
+  const colors = useColors();
+  const [approveNotes, setApproveNotes] = useState("");
+
+  const handleClose = () => {
+    setApproveNotes("");
+    onClose();
+  };
+
+  const borderColor = colors.isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)";
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      PaperProps={{
+        sx: {
+          backgroundColor: colors.isDark ? "#111" : "#fff",
+          borderRadius: "16px",
+          border: `1px solid ${borderColor}`,
+          minWidth: 360,
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontWeight: 700,
+          color: colors.textPrimary,
+        }}
+      >
+        Approve Submission
+      </DialogTitle>
+      <DialogContent>
+        <Typography
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontSize: "13px",
+            color: colors.textSecondary,
+            mb: 2,
+          }}
+        >
+          Optional: add a note for the member:
+        </Typography>
+        <TextField
+          value={approveNotes}
+          onChange={(e) => setApproveNotes(e.target.value)}
+          placeholder="Great work! We'll be featuring this soon..."
+          multiline
+          rows={2}
+          fullWidth
+          sx={{
+            "& .MuiOutlinedInput-root": {
+              fontFamily: "Montserrat, sans-serif",
+              color: colors.textPrimary,
+              "& fieldset": { borderColor },
+            },
+          }}
+          inputProps={{ style: { fontFamily: "Montserrat, sans-serif" } }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2, gap: 1 }}>
+        <Button
+          onClick={handleClose}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            textTransform: "none",
+            color: colors.textSecondary,
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={() => onConfirm(approveNotes || undefined)}
+          disabled={loading}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 700,
+            textTransform: "none",
+            backgroundColor: "#2ECC71",
+            color: "#000",
+            borderRadius: "8px",
+            px: 2,
+            "&:hover": { backgroundColor: "#27ae60" },
+          }}
+        >
+          {loading ? <CircularProgress size={16} sx={{ color: "#000" }} /> : "Confirm Approve"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const VaultAdminQueue = () => {
+  const colors = useColors();
+  const [activeTab, setActiveTab] = useState(0);
+  const [detailSubmission, setDetailSubmission] = useState(null);
+  const [approveTarget, setApproveTarget] = useState(null);
+  const [rejectTarget, setRejectTarget] = useState(null);
+
+  const statusFilter = STATUS_TABS[activeTab].value;
+
+  const { data, loading, error, refetch } = useQuery(GET_ADMIN_VAULT_QUEUE, {
+    variables: {
+      status: statusFilter,
+      limit: 50,
+      offset: 0,
+    },
+    fetchPolicy: "cache-and-network",
+  });
+
+  const [approveSubmission, { loading: approving }] = useMutation(
+    APPROVE_VAULT_SUBMISSION,
+    { onCompleted: () => refetch() }
+  );
+  const [rejectSubmission, { loading: rejecting }] = useMutation(
+    REJECT_VAULT_SUBMISSION,
+    { onCompleted: () => refetch() }
+  );
+  const [featureSubmission, { loading: featuring }] = useMutation(
+    FEATURE_VAULT_SUBMISSION,
+    { onCompleted: () => refetch() }
+  );
+  const [publishSubmission, { loading: publishing }] = useMutation(
+    PUBLISH_VAULT_SUBMISSION,
+    { onCompleted: () => refetch() }
+  );
+
+  const handleApprove = async (id, notes) => {
+    await approveSubmission({ variables: { id, notes } });
+    setApproveTarget(null);
+  };
+
+  const handleReject = async (id, notes) => {
+    await rejectSubmission({ variables: { id, notes } });
+    setRejectTarget(null);
+  };
+
+  const handleFeature = async (submission) => {
+    await featureSubmission({
+      variables: { id: submission.id, featured: !submission.isFeatured },
+    });
+  };
+
+  const handlePublish = async (id) => {
+    await publishSubmission({ variables: { id } });
+  };
+
+  const handleDetailAction = (updated) => {
+    setDetailSubmission(updated);
+    refetch();
+  };
+
+  const borderColor = colors.isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)";
+  const tableBg = colors.isDark ? "#0a0a0a" : "#fafafa";
+  const headerBg = colors.isDark ? "#111" : "#f3f3f3";
+  const rowHover = colors.isDark ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.02)";
+
+  const items = data?.adminVaultQueue?.items || [];
+
+  return (
+    <Box>
+      <Typography
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontWeight: 700,
+          fontSize: "1.1rem",
+          color: colors.textPrimary,
+          mb: 2,
+        }}
+      >
+        Admin Moderation Queue
+      </Typography>
+
+      {/* Tabs */}
+      <Tabs
+        value={activeTab}
+        onChange={(_, val) => setActiveTab(val)}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{
+          mb: 3,
+          borderBottom: `1px solid ${borderColor}`,
+          "& .MuiTab-root": {
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 600,
+            fontSize: "12px",
+            textTransform: "none",
+            color: colors.textSecondary,
+            minWidth: "auto",
+            px: 2,
+          },
+          "& .Mui-selected": { color: `${colors.warning} !important` },
+          "& .MuiTabs-indicator": { backgroundColor: colors.warning },
+        }}
+      >
+        {STATUS_TABS.map((tab, i) => (
+          <Tab key={tab.label} label={tab.label} value={i} />
+        ))}
+      </Tabs>
+
+      {/* Error */}
+      {error && (
+        <Alert
+          severity="error"
+          action={
+            <Button
+              onClick={() => refetch()}
+              size="small"
+              sx={{ fontFamily: "Montserrat, sans-serif", color: "#e74c3c" }}
+            >
+              Retry
+            </Button>
+          }
+          sx={{ mb: 2, fontFamily: "Montserrat, sans-serif", fontSize: "13px" }}
+        >
+          Failed to load queue: {error.message}
+        </Alert>
+      )}
+
+      {/* Table */}
+      <TableContainer
+        sx={{
+          border: `1px solid ${borderColor}`,
+          borderRadius: "12px",
+          backgroundColor: tableBg,
+          overflow: "hidden",
+        }}
+      >
+        <Table size="small">
+          <TableHead>
+            <TableRow sx={{ backgroundColor: headerBg }}>
+              {["Member", "Title", "Category", "Status", "Submitted", "Actions"].map(
+                (header) => (
+                  <TableCell
+                    key={header}
+                    sx={{
+                      fontFamily: "Montserrat, sans-serif",
+                      fontWeight: 700,
+                      fontSize: "11px",
+                      color: colors.textSecondary,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.05em",
+                      borderBottom: `1px solid ${borderColor}`,
+                      py: 1.5,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {header}
+                  </TableCell>
+                )
+              )}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading &&
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  {Array.from({ length: 6 }).map((__, j) => (
+                    <TableCell key={j} sx={{ borderBottom: `1px solid ${borderColor}` }}>
+                      <Skeleton
+                        variant="text"
+                        sx={{ backgroundColor: colors.isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)" }}
+                      />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+
+            {!loading && items.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  align="center"
+                  sx={{
+                    py: 6,
+                    fontFamily: "Montserrat, sans-serif",
+                    fontSize: "14px",
+                    color: colors.textSecondary,
+                    borderBottom: "none",
+                  }}
+                >
+                  No submissions found
+                </TableCell>
+              </TableRow>
+            )}
+
+            {!loading &&
+              items.map((item) => {
+                const statusCfg = STATUS_CONFIG[item.status] || STATUS_CONFIG.draft;
+                const memberName = item.member
+                  ? `${item.member.firstName || ""} ${item.member.lastName || ""}`.trim() ||
+                    item.member.businessName ||
+                    "—"
+                  : "—";
+
+                return (
+                  <TableRow
+                    key={item.id}
+                    hover
+                    onClick={() => setDetailSubmission(item)}
+                    sx={{
+                      cursor: "pointer",
+                      "&:hover": { backgroundColor: rowHover },
+                      "&:last-child td": { borderBottom: "none" },
+                    }}
+                  >
+                    <TableCell
+                      sx={{
+                        fontFamily: "Montserrat, sans-serif",
+                        fontSize: "13px",
+                        color: colors.textPrimary,
+                        borderBottom: `1px solid ${borderColor}`,
+                        py: 1.5,
+                        maxWidth: "140px",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {memberName}
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        fontFamily: "Montserrat, sans-serif",
+                        fontSize: "13px",
+                        color: colors.textPrimary,
+                        borderBottom: `1px solid ${borderColor}`,
+                        py: 1.5,
+                        maxWidth: "200px",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {item.title}
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        borderBottom: `1px solid ${borderColor}`,
+                        py: 1.5,
+                      }}
+                    >
+                      {item.category && (
+                        <Chip
+                          label={item.category}
+                          size="small"
+                          sx={{
+                            fontFamily: "Montserrat, sans-serif",
+                            fontSize: "10px",
+                            height: "20px",
+                            color: colors.warning,
+                            border: `1px solid ${colors.warning}`,
+                            backgroundColor: "transparent",
+                          }}
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        borderBottom: `1px solid ${borderColor}`,
+                        py: 1.5,
+                      }}
+                    >
+                      <Chip
+                        label={statusCfg.label}
+                        size="small"
+                        sx={{
+                          fontFamily: "Montserrat, sans-serif",
+                          fontWeight: 700,
+                          fontSize: "10px",
+                          height: "20px",
+                          backgroundColor: statusCfg.bg,
+                          color: statusCfg.color,
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        fontFamily: "Montserrat, sans-serif",
+                        fontSize: "12px",
+                        color: colors.textSecondary,
+                        borderBottom: `1px solid ${borderColor}`,
+                        py: 1.5,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {formatDate(item.createdAt)}
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        borderBottom: `1px solid ${borderColor}`,
+                        py: 1.5,
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Box sx={{ display: "flex", gap: 0.5, alignItems: "center" }}>
+                        <Tooltip title="View Details">
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDetailSubmission(item);
+                            }}
+                            sx={{ color: colors.textSecondary, "&:hover": { color: colors.warning } }}
+                          >
+                            <VisibilityOutlined sx={{ fontSize: 16 }} />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Approve">
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setApproveTarget(item);
+                            }}
+                            disabled={item.status === "approved" || approving}
+                            sx={{
+                              color: "#2ECC71",
+                              "&:hover": { backgroundColor: "rgba(46,204,113,0.1)" },
+                              "&.Mui-disabled": { opacity: 0.3 },
+                            }}
+                          >
+                            <CheckCircleOutlined sx={{ fontSize: 16 }} />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Reject">
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setRejectTarget(item);
+                            }}
+                            disabled={item.status === "rejected" || rejecting}
+                            sx={{
+                              color: "#e74c3c",
+                              "&:hover": { backgroundColor: "rgba(231,76,60,0.1)" },
+                              "&.Mui-disabled": { opacity: 0.3 },
+                            }}
+                          >
+                            <CancelOutlined sx={{ fontSize: 16 }} />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title={item.isFeatured ? "Unfeature" : "Feature"}>
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleFeature(item);
+                            }}
+                            disabled={featuring}
+                            sx={{
+                              color: colors.warning,
+                              "&:hover": { backgroundColor: "rgba(255,195,28,0.1)" },
+                            }}
+                          >
+                            {item.isFeatured ? (
+                              <StarOutlined sx={{ fontSize: 16 }} />
+                            ) : (
+                              <StarBorderOutlined sx={{ fontSize: 16 }} />
+                            )}
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Publish">
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handlePublish(item.id);
+                            }}
+                            disabled={
+                              item.status === "published" ||
+                              !item.isApproved ||
+                              publishing
+                            }
+                            sx={{
+                              color: "#9B59B6",
+                              "&:hover": { backgroundColor: "rgba(155,89,182,0.1)" },
+                              "&.Mui-disabled": { opacity: 0.3 },
+                            }}
+                          >
+                            <PublishOutlined sx={{ fontSize: 16 }} />
+                          </IconButton>
+                        </Tooltip>
+                      </Box>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Detail modal */}
+      {detailSubmission && (
+        <VaultDetailModal
+          submission={detailSubmission}
+          open={Boolean(detailSubmission)}
+          onClose={() => setDetailSubmission(null)}
+          onAction={handleDetailAction}
+        />
+      )}
+
+      {/* Approve dialog */}
+      <ApproveDialog
+        open={Boolean(approveTarget)}
+        onClose={() => setApproveTarget(null)}
+        onConfirm={(notes) => handleApprove(approveTarget?.id, notes)}
+        loading={approving}
+      />
+
+      {/* Reject dialog */}
+      <RejectDialog
+        open={Boolean(rejectTarget)}
+        onClose={() => setRejectTarget(null)}
+        onConfirm={(notes) => handleReject(rejectTarget?.id, notes)}
+        loading={rejecting}
+      />
+    </Box>
+  );
+};
+
+export default VaultAdminQueue;

--- a/src/pages/Vault/VaultDetailModal.jsx
+++ b/src/pages/Vault/VaultDetailModal.jsx
@@ -1,0 +1,557 @@
+import React, { useState } from "react";
+import {
+  Modal,
+  Box,
+  Typography,
+  IconButton,
+  Button,
+  TextField,
+  Chip,
+  Alert,
+  CircularProgress,
+  Divider,
+} from "@mui/material";
+import {
+  CloseOutlined,
+  CheckCircleOutlined,
+  CancelOutlined,
+  StarOutlined,
+  StarBorderOutlined,
+  PublishOutlined,
+  VerifiedOutlined,
+} from "@mui/icons-material";
+import { useMutation } from "@apollo/client";
+import { useColors } from "../../theme/colors";
+import {
+  APPROVE_VAULT_SUBMISSION,
+  REJECT_VAULT_SUBMISSION,
+  FEATURE_VAULT_SUBMISSION,
+  PUBLISH_VAULT_SUBMISSION,
+} from "../../context/graphql/getVault";
+
+const STATUS_CONFIG = {
+  draft: { label: "Draft", color: "#888" },
+  pending: { label: "Pending", color: "#D4AC0D" },
+  underReview: { label: "Under Review", color: "#3498DB" },
+  under_review: { label: "Under Review", color: "#3498DB" },
+  approved: { label: "Approved", color: "#2ECC71" },
+  rejected: { label: "Rejected", color: "#e74c3c" },
+  published: { label: "Published", color: "#9B59B6" },
+};
+
+const VaultDetailModal = ({ submission, open, onClose, onAction }) => {
+  const colors = useColors();
+  const [rejectMode, setRejectMode] = useState(false);
+  const [approveMode, setApproveMode] = useState(false);
+  const [notes, setNotes] = useState(submission?.adminNotes || "");
+  const [actionError, setActionError] = useState("");
+
+  const [approveSubmission, { loading: approving }] = useMutation(
+    APPROVE_VAULT_SUBMISSION
+  );
+  const [rejectSubmission, { loading: rejecting }] = useMutation(
+    REJECT_VAULT_SUBMISSION
+  );
+  const [featureSubmission, { loading: featuring }] = useMutation(
+    FEATURE_VAULT_SUBMISSION
+  );
+  const [publishSubmission, { loading: publishing }] = useMutation(
+    PUBLISH_VAULT_SUBMISSION
+  );
+
+  if (!submission) return null;
+
+  const isLoading = approving || rejecting || featuring || publishing;
+  const statusCfg = STATUS_CONFIG[submission.status] || STATUS_CONFIG.draft;
+
+  const handleApprove = async () => {
+    setActionError("");
+    try {
+      const { data } = await approveSubmission({
+        variables: { id: submission.id, notes: notes || undefined },
+      });
+      onAction({ ...submission, ...data.approveVaultSubmission });
+      setApproveMode(false);
+    } catch (err) {
+      setActionError(err.message || "Approval failed.");
+    }
+  };
+
+  const handleReject = async () => {
+    if (!notes.trim()) {
+      setActionError("Rejection notes are required.");
+      return;
+    }
+    setActionError("");
+    try {
+      const { data } = await rejectSubmission({
+        variables: { id: submission.id, notes: notes.trim() },
+      });
+      onAction({ ...submission, ...data.rejectVaultSubmission });
+      setRejectMode(false);
+    } catch (err) {
+      setActionError(err.message || "Rejection failed.");
+    }
+  };
+
+  const handleFeature = async () => {
+    setActionError("");
+    try {
+      const { data } = await featureSubmission({
+        variables: { id: submission.id, featured: !submission.isFeatured },
+      });
+      onAction({ ...submission, ...data.featureVaultSubmission });
+    } catch (err) {
+      setActionError(err.message || "Feature toggle failed.");
+    }
+  };
+
+  const handlePublish = async () => {
+    setActionError("");
+    try {
+      const { data } = await publishSubmission({
+        variables: { id: submission.id },
+      });
+      onAction({ ...submission, ...data.publishVaultSubmission });
+    } catch (err) {
+      setActionError(err.message || "Publish failed.");
+    }
+  };
+
+  const modalBg = colors.isDark ? "#0d0d0d" : "#fff";
+  const borderColor = colors.isDark
+    ? "rgba(255,255,255,0.1)"
+    : "rgba(0,0,0,0.1)";
+
+  const memberName = submission.member
+    ? `${submission.member.firstName || ""} ${submission.member.lastName || ""}`.trim() ||
+      submission.member.businessName ||
+      "Unknown Member"
+    : "Unknown Member";
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: { xs: "95vw", sm: "680px" },
+          maxHeight: "90vh",
+          overflowY: "auto",
+          backgroundColor: modalBg,
+          border: `1px solid ${borderColor}`,
+          borderRadius: "20px",
+          boxShadow: "0 24px 80px rgba(0,0,0,0.5)",
+          p: { xs: 2.5, sm: 4 },
+        }}
+      >
+        {/* Header */}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            mb: 3,
+          }}
+        >
+          <Box>
+            <Typography
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontWeight: 700,
+                fontSize: "1.1rem",
+                color: colors.textPrimary,
+                mb: 0.5,
+              }}
+            >
+              {submission.title}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "12px",
+                color: colors.textSecondary,
+              }}
+            >
+              By {memberName}
+            </Typography>
+          </Box>
+          <IconButton
+            onClick={onClose}
+            sx={{ color: colors.textSecondary, mt: -0.5 }}
+          >
+            <CloseOutlined />
+          </IconButton>
+        </Box>
+
+        {/* Status + badges */}
+        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 3 }}>
+          <Chip
+            label={statusCfg.label}
+            size="small"
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontWeight: 700,
+              fontSize: "11px",
+              color: statusCfg.color,
+              border: `1px solid ${statusCfg.color}`,
+              backgroundColor: "transparent",
+            }}
+          />
+          {submission.category && (
+            <Chip
+              label={submission.category}
+              size="small"
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "11px",
+                color: colors.warning,
+                border: `1px solid ${colors.warning}`,
+                backgroundColor: "transparent",
+              }}
+            />
+          )}
+          {submission.isFeatured && (
+            <Chip
+              label="Featured"
+              size="small"
+              icon={<StarOutlined sx={{ fontSize: 12, color: "#000 !important" }} />}
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontWeight: 700,
+                fontSize: "11px",
+                backgroundColor: colors.warning,
+                color: "#000",
+              }}
+            />
+          )}
+          {submission.consentAccepted && (
+            <Chip
+              label="Consent Given"
+              size="small"
+              icon={<VerifiedOutlined sx={{ fontSize: 12, color: "#2ECC71 !important" }} />}
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "11px",
+                color: "#2ECC71",
+                border: "1px solid #2ECC71",
+                backgroundColor: "transparent",
+              }}
+            />
+          )}
+        </Box>
+
+        {/* Media */}
+        {submission.mediaUrls?.length > 0 && (
+          <Box sx={{ mb: 3 }}>
+            {submission.category === "Video" || submission.mediaUrls[0]?.includes("blob:") ? (
+              <Box
+                component="video"
+                src={submission.mediaUrls[0]}
+                controls
+                sx={{
+                  width: "100%",
+                  maxHeight: "300px",
+                  borderRadius: "12px",
+                  display: "block",
+                }}
+              />
+            ) : (
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: submission.mediaUrls.length === 1 ? "1fr" : "1fr 1fr",
+                  gap: 1,
+                }}
+              >
+                {submission.mediaUrls.map((url, i) => (
+                  <Box
+                    key={i}
+                    component="img"
+                    src={url}
+                    alt={`Media ${i + 1}`}
+                    sx={{
+                      width: "100%",
+                      height: submission.mediaUrls.length === 1 ? "280px" : "160px",
+                      objectFit: "cover",
+                      borderRadius: "10px",
+                    }}
+                  />
+                ))}
+              </Box>
+            )}
+          </Box>
+        )}
+
+        {/* Description */}
+        {submission.description && (
+          <Box sx={{ mb: 3 }}>
+            <Typography
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "13px",
+                fontWeight: 600,
+                color: colors.textSecondary,
+                mb: 0.5,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              Description
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "14px",
+                color: colors.textPrimary,
+                lineHeight: 1.6,
+              }}
+            >
+              {submission.description}
+            </Typography>
+          </Box>
+        )}
+
+        {/* Platforms */}
+        {submission.platforms?.length > 0 && (
+          <Box sx={{ mb: 3 }}>
+            <Typography
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "13px",
+                fontWeight: 600,
+                color: colors.textSecondary,
+                mb: 1,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              Platforms
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              {submission.platforms.map((p) => (
+                <Chip
+                  key={p}
+                  label={p}
+                  size="small"
+                  sx={{
+                    fontFamily: "Montserrat, sans-serif",
+                    fontSize: "11px",
+                    backgroundColor: colors.isDark
+                      ? "rgba(255,255,255,0.08)"
+                      : "rgba(0,0,0,0.06)",
+                    color: colors.textPrimary,
+                  }}
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+
+        <Divider sx={{ borderColor, mb: 3 }} />
+
+        {/* Admin notes (editable) */}
+        <Box sx={{ mb: 3 }}>
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontSize: "13px",
+              fontWeight: 600,
+              color: colors.textSecondary,
+              mb: 1,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            Admin Notes
+          </Typography>
+          <TextField
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Add notes for this submission..."
+            multiline
+            rows={3}
+            fullWidth
+            disabled={isLoading}
+            sx={{
+              "& .MuiOutlinedInput-root": {
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "13px",
+                color: colors.textPrimary,
+                "& fieldset": { borderColor },
+                "&:hover fieldset": { borderColor: colors.warning },
+                "&.Mui-focused fieldset": { borderColor: colors.warning },
+              },
+            }}
+            inputProps={{ style: { fontFamily: "Montserrat, sans-serif" } }}
+          />
+        </Box>
+
+        {/* Error */}
+        {actionError && (
+          <Alert
+            severity="error"
+            sx={{ mb: 2, fontFamily: "Montserrat, sans-serif", fontSize: "13px" }}
+          >
+            {actionError}
+          </Alert>
+        )}
+
+        {/* Inline reject confirmation */}
+        {rejectMode && (
+          <Alert
+            severity="warning"
+            sx={{ mb: 2, fontFamily: "Montserrat, sans-serif", fontSize: "13px" }}
+          >
+            Notes above are required for rejection. Fill in the Admin Notes field
+            then click Confirm Reject.
+          </Alert>
+        )}
+
+        {/* Action buttons */}
+        <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
+          {/* Approve */}
+          {!rejectMode && (
+            <Button
+              variant="contained"
+              startIcon={
+                approving ? (
+                  <CircularProgress size={14} sx={{ color: "#000" }} />
+                ) : (
+                  <CheckCircleOutlined />
+                )
+              }
+              onClick={approveMode ? handleApprove : () => setApproveMode(true)}
+              disabled={isLoading || submission.status === "approved"}
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontWeight: 700,
+                fontSize: "13px",
+                textTransform: "none",
+                backgroundColor: "#2ECC71",
+                color: "#000",
+                borderRadius: "10px",
+                "&:hover": { backgroundColor: "#27ae60" },
+                "&.Mui-disabled": { opacity: 0.5 },
+              }}
+            >
+              {approveMode ? "Confirm Approve" : "Approve"}
+            </Button>
+          )}
+
+          {/* Reject */}
+          {!approveMode && (
+            <Button
+              variant="contained"
+              startIcon={
+                rejecting ? (
+                  <CircularProgress size={14} sx={{ color: "#fff" }} />
+                ) : (
+                  <CancelOutlined />
+                )
+              }
+              onClick={rejectMode ? handleReject : () => setRejectMode(true)}
+              disabled={isLoading || submission.status === "rejected"}
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontWeight: 700,
+                fontSize: "13px",
+                textTransform: "none",
+                backgroundColor: "#e74c3c",
+                color: "#fff",
+                borderRadius: "10px",
+                "&:hover": { backgroundColor: "#c0392b" },
+                "&.Mui-disabled": { opacity: 0.5 },
+              }}
+            >
+              {rejectMode ? "Confirm Reject" : "Reject"}
+            </Button>
+          )}
+
+          {/* Feature toggle */}
+          <Button
+            variant="outlined"
+            startIcon={
+              featuring ? (
+                <CircularProgress size={14} />
+              ) : submission.isFeatured ? (
+                <StarOutlined />
+              ) : (
+                <StarBorderOutlined />
+              )
+            }
+            onClick={handleFeature}
+            disabled={isLoading}
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontWeight: 600,
+              fontSize: "13px",
+              textTransform: "none",
+              borderColor: colors.warning,
+              color: colors.warning,
+              borderRadius: "10px",
+              "&:hover": { backgroundColor: "rgba(255,195,28,0.08)" },
+            }}
+          >
+            {submission.isFeatured ? "Unfeature" : "Feature"}
+          </Button>
+
+          {/* Publish */}
+          <Button
+            variant="outlined"
+            startIcon={
+              publishing ? (
+                <CircularProgress size={14} />
+              ) : (
+                <PublishOutlined />
+              )
+            }
+            onClick={handlePublish}
+            disabled={
+              isLoading ||
+              submission.status === "published" ||
+              !submission.isApproved
+            }
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontWeight: 600,
+              fontSize: "13px",
+              textTransform: "none",
+              borderColor: "#9B59B6",
+              color: "#9B59B6",
+              borderRadius: "10px",
+              "&:hover": { backgroundColor: "rgba(155,89,182,0.08)" },
+              "&.Mui-disabled": { opacity: 0.4 },
+            }}
+          >
+            Publish
+          </Button>
+
+          {/* Cancel inline mode */}
+          {(approveMode || rejectMode) && (
+            <Button
+              variant="text"
+              onClick={() => {
+                setApproveMode(false);
+                setRejectMode(false);
+                setActionError("");
+              }}
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "13px",
+                textTransform: "none",
+                color: colors.textSecondary,
+              }}
+            >
+              Cancel
+            </Button>
+          )}
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+export default VaultDetailModal;

--- a/src/pages/Vault/VaultMediaUploader.jsx
+++ b/src/pages/Vault/VaultMediaUploader.jsx
@@ -1,0 +1,301 @@
+import React, { useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Typography,
+  IconButton,
+  LinearProgress,
+} from "@mui/material";
+import {
+  ImageOutlined,
+  VideocamOutlined,
+  CloseOutlined,
+} from "@mui/icons-material";
+import { useColors } from "../../theme/colors";
+
+const MAX_IMAGES = 5;
+
+const VaultMediaUploader = ({
+  mediaUrls = [],
+  mediaType = "none",
+  onMediaChange,
+  disabled = false,
+  uploading = false,
+}) => {
+  const colors = useColors();
+  const imageInputRef = useRef(null);
+  const videoInputRef = useRef(null);
+  const [error, setError] = useState("");
+
+  const handleImageSelect = (e) => {
+    setError("");
+    const files = Array.from(e.target.files || []);
+    if (!files.length) return;
+
+    const currentCount = mediaType === "image" ? mediaUrls.length : 0;
+    if (currentCount + files.length > MAX_IMAGES) {
+      setError(`You can upload a maximum of ${MAX_IMAGES} photos.`);
+      e.target.value = "";
+      return;
+    }
+
+    const previews = files.map((f) => URL.createObjectURL(f));
+    const combined = mediaType === "image" ? [...mediaUrls, ...previews] : previews;
+    onMediaChange(combined, "image");
+    e.target.value = "";
+  };
+
+  const handleVideoSelect = (e) => {
+    setError("");
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("video/")) {
+      setError("Please select a valid video file.");
+      e.target.value = "";
+      return;
+    }
+
+    const preview = URL.createObjectURL(file);
+    onMediaChange([preview], "video");
+    e.target.value = "";
+  };
+
+  const handleRemoveImage = (index) => {
+    const updated = mediaUrls.filter((_, i) => i !== index);
+    if (updated.length === 0) {
+      onMediaChange([], "none");
+    } else {
+      onMediaChange(updated, "image");
+    }
+  };
+
+  const handleRemoveVideo = () => {
+    onMediaChange([], "none");
+  };
+
+  const borderColor = colors.isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.12)";
+  const bg = colors.isDark ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.02)";
+
+  return (
+    <Box>
+      {/* Hidden file inputs */}
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        style={{ display: "none" }}
+        onChange={handleImageSelect}
+        disabled={disabled}
+      />
+      <input
+        ref={videoInputRef}
+        type="file"
+        accept="video/*"
+        style={{ display: "none" }}
+        onChange={handleVideoSelect}
+        disabled={disabled}
+      />
+
+      {/* Upload buttons */}
+      <Box sx={{ display: "flex", gap: 1.5, mb: 2 }}>
+        <Button
+          variant="outlined"
+          startIcon={<ImageOutlined />}
+          onClick={() => imageInputRef.current?.click()}
+          disabled={disabled || mediaType === "video"}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 600,
+            fontSize: "13px",
+            textTransform: "none",
+            borderColor: colors.isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.3)",
+            color: colors.textPrimary,
+            borderRadius: "10px",
+            "&:hover": {
+              borderColor: colors.warning,
+              color: colors.warning,
+            },
+            "&.Mui-disabled": {
+              opacity: 0.4,
+            },
+          }}
+        >
+          Add Photos
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={<VideocamOutlined />}
+          onClick={() => videoInputRef.current?.click()}
+          disabled={disabled || mediaType === "image"}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 600,
+            fontSize: "13px",
+            textTransform: "none",
+            borderColor: colors.isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.3)",
+            color: colors.textPrimary,
+            borderRadius: "10px",
+            "&:hover": {
+              borderColor: colors.warning,
+              color: colors.warning,
+            },
+            "&.Mui-disabled": {
+              opacity: 0.4,
+            },
+          }}
+        >
+          Add Video
+        </Button>
+      </Box>
+
+      {/* Progress bar */}
+      {uploading && (
+        <Box sx={{ mb: 2 }}>
+          <LinearProgress
+            sx={{
+              borderRadius: 2,
+              backgroundColor: colors.isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.08)",
+              "& .MuiLinearProgress-bar": { backgroundColor: colors.warning },
+            }}
+          />
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontSize: "12px",
+              color: colors.textSecondary,
+              mt: 0.5,
+            }}
+          >
+            Uploading...
+          </Typography>
+        </Box>
+      )}
+
+      {/* Error */}
+      {error && (
+        <Typography
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontSize: "12px",
+            color: "#e74c3c",
+            mb: 1.5,
+          }}
+        >
+          {error}
+        </Typography>
+      )}
+
+      {/* Image preview grid */}
+      {mediaType === "image" && mediaUrls.length > 0 && (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 1.5,
+            p: 1.5,
+            border: `1px solid ${borderColor}`,
+            borderRadius: "12px",
+            backgroundColor: bg,
+          }}
+        >
+          {mediaUrls.map((url, i) => (
+            <Box
+              key={i}
+              sx={{ position: "relative", borderRadius: "8px", overflow: "hidden" }}
+            >
+              <Box
+                component="img"
+                src={url}
+                alt={`Preview ${i + 1}`}
+                sx={{
+                  width: "100%",
+                  height: "120px",
+                  objectFit: "cover",
+                  display: "block",
+                }}
+              />
+              <IconButton
+                size="small"
+                onClick={() => handleRemoveImage(i)}
+                disabled={disabled}
+                sx={{
+                  position: "absolute",
+                  top: 4,
+                  right: 4,
+                  backgroundColor: "rgba(0,0,0,0.65)",
+                  color: "#fff",
+                  padding: "2px",
+                  "&:hover": { backgroundColor: "rgba(0,0,0,0.85)" },
+                }}
+              >
+                <CloseOutlined sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {/* Video preview */}
+      {mediaType === "video" && mediaUrls.length > 0 && (
+        <Box
+          sx={{
+            position: "relative",
+            border: `1px solid ${borderColor}`,
+            borderRadius: "12px",
+            overflow: "hidden",
+            backgroundColor: bg,
+          }}
+        >
+          <Box
+            component="video"
+            src={mediaUrls[0]}
+            controls
+            sx={{ width: "100%", maxHeight: "280px", display: "block" }}
+          />
+          <IconButton
+            size="small"
+            onClick={handleRemoveVideo}
+            disabled={disabled}
+            sx={{
+              position: "absolute",
+              top: 8,
+              right: 8,
+              backgroundColor: "rgba(0,0,0,0.65)",
+              color: "#fff",
+              "&:hover": { backgroundColor: "rgba(0,0,0,0.85)" },
+            }}
+          >
+            <CloseOutlined sx={{ fontSize: 16 }} />
+          </IconButton>
+        </Box>
+      )}
+
+      {/* Empty state hint */}
+      {mediaType === "none" && (
+        <Box
+          sx={{
+            border: `1px dashed ${borderColor}`,
+            borderRadius: "12px",
+            p: 3,
+            textAlign: "center",
+            backgroundColor: bg,
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontSize: "13px",
+              color: colors.textSecondary,
+            }}
+          >
+            Add up to 5 photos or 1 video
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default VaultMediaUploader;

--- a/src/pages/Vault/VaultSubmissionCard.jsx
+++ b/src/pages/Vault/VaultSubmissionCard.jsx
@@ -1,0 +1,347 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Typography,
+  Chip,
+  IconButton,
+  Button,
+  Alert,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from "@mui/material";
+import {
+  EditOutlined,
+  DeleteOutlined,
+  ImageOutlined,
+} from "@mui/icons-material";
+import { useMutation } from "@apollo/client";
+import { useColors } from "../../theme/colors";
+import {
+  DELETE_VAULT_SUBMISSION,
+  GET_VAULT_SUBMISSIONS,
+} from "../../context/graphql/getVault";
+
+const STATUS_CONFIG = {
+  draft: { label: "Draft", color: "#888", bg: "rgba(136,136,136,0.15)" },
+  pending: { label: "Pending", color: "#D4AC0D", bg: "rgba(212,172,13,0.15)" },
+  underReview: { label: "Under Review", color: "#3498DB", bg: "rgba(52,152,219,0.15)" },
+  under_review: { label: "Under Review", color: "#3498DB", bg: "rgba(52,152,219,0.15)" },
+  approved: { label: "Approved", color: "#2ECC71", bg: "rgba(46,204,113,0.15)" },
+  rejected: { label: "Rejected", color: "#e74c3c", bg: "rgba(231,76,60,0.15)" },
+  published: { label: "Published", color: "#9B59B6", bg: "rgba(155,89,182,0.15)" },
+};
+
+const formatRelative = (dateStr) => {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now - date;
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.floor(diffH / 24);
+  if (diffD < 30) return `${diffD}d ago`;
+  return date.toLocaleDateString();
+};
+
+const VaultSubmissionCard = ({ submission, onEdit, onDelete }) => {
+  const colors = useColors();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const [deleteSubmission, { loading: deleting }] = useMutation(
+    DELETE_VAULT_SUBMISSION,
+    {
+      update(cache) {
+        cache.modify({
+          fields: {
+            vaultSubmissions(existing = [], { readField }) {
+              return existing.filter(
+                (ref) => readField("id", ref) !== submission.id
+              );
+            },
+          },
+        });
+      },
+      refetchQueries: [{ query: GET_VAULT_SUBMISSIONS }],
+    }
+  );
+
+  const statusCfg =
+    STATUS_CONFIG[submission.status] || STATUS_CONFIG.draft;
+
+  const canEditOrDelete =
+    submission.status === "draft" || submission.status === "pending";
+
+  const thumbnailUrl =
+    submission.thumbnailUrl ||
+    (submission.mediaUrls?.length ? submission.mediaUrls[0] : null);
+
+  const handleDelete = async () => {
+    try {
+      await deleteSubmission({ variables: { id: submission.id } });
+      setConfirmOpen(false);
+      if (onDelete) onDelete(submission.id);
+    } catch (err) {
+      console.error("Delete failed:", err);
+    }
+  };
+
+  const cardBg = colors.isDark ? "#0d0d0d" : "#f8f8f8";
+  const borderColor = colors.isDark
+    ? "rgba(255,255,255,0.08)"
+    : "rgba(0,0,0,0.08)";
+
+  return (
+    <>
+      <Box
+        sx={{
+          backgroundColor: cardBg,
+          border: `1px solid ${borderColor}`,
+          borderRadius: "16px",
+          overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Thumbnail */}
+        <Box
+          sx={{
+            width: "100%",
+            height: "160px",
+            backgroundColor: colors.isDark
+              ? "rgba(255,255,255,0.04)"
+              : "rgba(0,0,0,0.04)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            overflow: "hidden",
+            position: "relative",
+          }}
+        >
+          {thumbnailUrl ? (
+            <Box
+              component="img"
+              src={thumbnailUrl}
+              alt={submission.title}
+              sx={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+              }}
+            />
+          ) : (
+            <ImageOutlined
+              sx={{
+                fontSize: 48,
+                color: colors.isDark
+                  ? "rgba(255,255,255,0.15)"
+                  : "rgba(0,0,0,0.12)",
+              }}
+            />
+          )}
+
+          {/* Status chip overlay */}
+          <Box sx={{ position: "absolute", top: 8, right: 8 }}>
+            <Chip
+              label={statusCfg.label}
+              size="small"
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontWeight: 700,
+                fontSize: "11px",
+                backgroundColor: statusCfg.bg,
+                color: statusCfg.color,
+                border: `1px solid ${statusCfg.color}`,
+                backdropFilter: "blur(4px)",
+              }}
+            />
+          </Box>
+
+          {/* Featured badge */}
+          {submission.isFeatured && (
+            <Box sx={{ position: "absolute", top: 8, left: 8 }}>
+              <Chip
+                label="Featured"
+                size="small"
+                sx={{
+                  fontFamily: "Montserrat, sans-serif",
+                  fontWeight: 700,
+                  fontSize: "11px",
+                  backgroundColor: colors.warning,
+                  color: "#000",
+                }}
+              />
+            </Box>
+          )}
+        </Box>
+
+        {/* Content */}
+        <Box sx={{ p: 2, flex: 1, display: "flex", flexDirection: "column", gap: 1 }}>
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontWeight: 700,
+              fontSize: "14px",
+              color: colors.textPrimary,
+              lineHeight: 1.3,
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {submission.title}
+          </Typography>
+
+          {submission.category && (
+            <Chip
+              label={submission.category}
+              size="small"
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "11px",
+                fontWeight: 600,
+                backgroundColor: colors.isDark
+                  ? "rgba(255,195,28,0.12)"
+                  : "rgba(255,195,28,0.15)",
+                color: colors.warning,
+                alignSelf: "flex-start",
+                height: "22px",
+              }}
+            />
+          )}
+
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontSize: "11px",
+              color: colors.textSecondary,
+            }}
+          >
+            {formatRelative(submission.createdAt)}
+          </Typography>
+
+          {/* Admin rejection notes */}
+          {submission.status === "rejected" && submission.adminNotes && (
+            <Alert
+              severity="error"
+              sx={{
+                fontFamily: "Montserrat, sans-serif",
+                fontSize: "12px",
+                borderRadius: "8px",
+                py: 0.5,
+                mt: 0.5,
+              }}
+            >
+              {submission.adminNotes}
+            </Alert>
+          )}
+
+          {/* Actions */}
+          {canEditOrDelete && (
+            <Box
+              sx={{
+                display: "flex",
+                gap: 1,
+                mt: "auto",
+                pt: 1,
+                borderTop: `1px solid ${borderColor}`,
+              }}
+            >
+              <IconButton
+                size="small"
+                onClick={() => onEdit && onEdit(submission)}
+                sx={{
+                  color: colors.textSecondary,
+                  "&:hover": { color: colors.warning },
+                }}
+              >
+                <EditOutlined sx={{ fontSize: 18 }} />
+              </IconButton>
+              <IconButton
+                size="small"
+                onClick={() => setConfirmOpen(true)}
+                disabled={deleting}
+                sx={{
+                  color: colors.textSecondary,
+                  "&:hover": { color: "#e74c3c" },
+                }}
+              >
+                <DeleteOutlined sx={{ fontSize: 18 }} />
+              </IconButton>
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        PaperProps={{
+          sx: {
+            backgroundColor: colors.isDark ? "#111" : "#fff",
+            borderRadius: "16px",
+            border: `1px solid ${borderColor}`,
+          },
+        }}
+      >
+        <DialogTitle
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 700,
+            color: colors.textPrimary,
+          }}
+        >
+          Delete Submission
+        </DialogTitle>
+        <DialogContent>
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontSize: "14px",
+              color: colors.textSecondary,
+            }}
+          >
+            Are you sure you want to delete "{submission.title}"? This action
+            cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2, gap: 1 }}>
+          <Button
+            onClick={() => setConfirmOpen(false)}
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              textTransform: "none",
+              color: colors.textSecondary,
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDelete}
+            disabled={deleting}
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontWeight: 700,
+              textTransform: "none",
+              backgroundColor: "#e74c3c",
+              color: "#fff",
+              borderRadius: "8px",
+              px: 2,
+              "&:hover": { backgroundColor: "#c0392b" },
+            }}
+          >
+            {deleting ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default VaultSubmissionCard;

--- a/src/pages/Vault/VaultSubmissionForm.jsx
+++ b/src/pages/Vault/VaultSubmissionForm.jsx
@@ -1,0 +1,430 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Typography,
+  TextField,
+  MenuItem,
+  Select,
+  FormControl,
+  InputLabel,
+  Chip,
+  Checkbox,
+  FormControlLabel,
+  Button,
+  Alert,
+  CircularProgress,
+} from "@mui/material";
+import { useMutation } from "@apollo/client";
+import { useColors } from "../../theme/colors";
+import VaultMediaUploader from "./VaultMediaUploader";
+import {
+  CREATE_VAULT_SUBMISSION,
+  UPDATE_VAULT_SUBMISSION,
+  GET_VAULT_SUBMISSIONS,
+} from "../../context/graphql/getVault";
+
+const CATEGORIES = ["Customization", "Merchandise", "Photo", "Video", "Other"];
+
+const PLATFORMS = ["Instagram", "TikTok", "Twitter/X", "YouTube", "Facebook"];
+
+const VaultSubmissionForm = ({ onSubmitted, onCancel, initialData }) => {
+  const colors = useColors();
+  const isEditMode = Boolean(initialData);
+
+  const [title, setTitle] = useState(initialData?.title || "");
+  const [description, setDescription] = useState(initialData?.description || "");
+  const [category, setCategory] = useState(initialData?.category || "");
+  const [selectedPlatforms, setSelectedPlatforms] = useState(
+    initialData?.platforms || []
+  );
+  const [mediaUrls, setMediaUrls] = useState(initialData?.mediaUrls || []);
+  const [mediaType, setMediaType] = useState(
+    initialData?.mediaUrls?.length
+      ? initialData.category === "Video"
+        ? "video"
+        : "image"
+      : "none"
+  );
+  const [consent, setConsent] = useState(initialData?.consentAccepted || false);
+  const [formError, setFormError] = useState("");
+
+  const [createSubmission, { loading: creating }] = useMutation(
+    CREATE_VAULT_SUBMISSION,
+    {
+      refetchQueries: [{ query: GET_VAULT_SUBMISSIONS }],
+    }
+  );
+
+  const [updateSubmission, { loading: updating }] = useMutation(
+    UPDATE_VAULT_SUBMISSION
+  );
+
+  const isSubmitting = creating || updating;
+
+  const togglePlatform = (platform) => {
+    setSelectedPlatforms((prev) =>
+      prev.includes(platform)
+        ? prev.filter((p) => p !== platform)
+        : [...prev, platform]
+    );
+  };
+
+  const handleMediaChange = (urls, type) => {
+    setMediaUrls(urls);
+    setMediaType(type);
+  };
+
+  const validate = () => {
+    if (!title.trim()) return "Title is required.";
+    if (mediaUrls.length === 0) return "Please add at least one photo or video.";
+    if (!consent) return "You must confirm content ownership before submitting.";
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setFormError(validationError);
+      return;
+    }
+    setFormError("");
+
+    try {
+      if (isEditMode) {
+        const { data } = await updateSubmission({
+          variables: {
+            id: initialData.id,
+            data: {
+              title: title.trim(),
+              description: description.trim(),
+              category,
+              platforms: selectedPlatforms,
+              mediaUrls,
+            },
+          },
+        });
+        onSubmitted(data.updateVaultSubmission);
+      } else {
+        const { data } = await createSubmission({
+          variables: {
+            data: {
+              title: title.trim(),
+              description: description.trim(),
+              category,
+              platforms: selectedPlatforms,
+              mediaUrls,
+              consentAccepted: consent,
+            },
+          },
+        });
+        onSubmitted(data.createVaultSubmission);
+      }
+    } catch (err) {
+      setFormError(err.message || "Something went wrong. Please try again.");
+    }
+  };
+
+  const handleSaveDraft = async () => {
+    if (!title.trim()) {
+      setFormError("Title is required to save a draft.");
+      return;
+    }
+    setFormError("");
+    try {
+      const { data } = await createSubmission({
+        variables: {
+          data: {
+            title: title.trim(),
+            description: description.trim(),
+            category,
+            platforms: selectedPlatforms,
+            mediaUrls,
+            consentAccepted: false,
+            status: "draft",
+          },
+        },
+      });
+      onSubmitted(data.createVaultSubmission);
+    } catch (err) {
+      setFormError(err.message || "Something went wrong. Please try again.");
+    }
+  };
+
+  const inputSx = {
+    "& .MuiOutlinedInput-root": {
+      fontFamily: "Montserrat, sans-serif",
+      color: colors.textPrimary,
+      "& fieldset": {
+        borderColor: colors.isDark ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.2)",
+      },
+      "&:hover fieldset": {
+        borderColor: colors.warning,
+      },
+      "&.Mui-focused fieldset": {
+        borderColor: colors.warning,
+      },
+    },
+    "& .MuiInputLabel-root": {
+      fontFamily: "Montserrat, sans-serif",
+      color: colors.textSecondary,
+      "&.Mui-focused": { color: colors.warning },
+    },
+    "& .MuiSelect-icon": { color: colors.textSecondary },
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Typography
+        sx={{
+          fontFamily: "Montserrat, sans-serif",
+          fontWeight: 700,
+          fontSize: "1.25rem",
+          color: colors.textPrimary,
+        }}
+      >
+        {isEditMode ? "Edit Submission" : "Submit Your Work"}
+      </Typography>
+
+      {/* Title */}
+      <TextField
+        label="Title *"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        fullWidth
+        disabled={isSubmitting}
+        sx={inputSx}
+        inputProps={{ style: { fontFamily: "Montserrat, sans-serif" } }}
+      />
+
+      {/* Description */}
+      <TextField
+        label="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        fullWidth
+        multiline
+        rows={4}
+        disabled={isSubmitting}
+        sx={inputSx}
+        inputProps={{ style: { fontFamily: "Montserrat, sans-serif" } }}
+      />
+
+      {/* Category */}
+      <FormControl fullWidth sx={inputSx}>
+        <InputLabel>Category</InputLabel>
+        <Select
+          value={category}
+          label="Category"
+          onChange={(e) => setCategory(e.target.value)}
+          disabled={isSubmitting}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            color: colors.textPrimary,
+          }}
+          MenuProps={{
+            PaperProps: {
+              sx: {
+                backgroundColor: colors.isDark ? "#1a1a1a" : "#fff",
+                color: colors.textPrimary,
+              },
+            },
+          }}
+        >
+          {CATEGORIES.map((cat) => (
+            <MenuItem
+              key={cat}
+              value={cat}
+              sx={{ fontFamily: "Montserrat, sans-serif" }}
+            >
+              {cat}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {/* Platforms */}
+      <Box>
+        <Typography
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontSize: "13px",
+            color: colors.textSecondary,
+            mb: 1,
+          }}
+        >
+          Platforms (select all that apply)
+        </Typography>
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+          {PLATFORMS.map((platform) => {
+            const selected = selectedPlatforms.includes(platform);
+            return (
+              <Chip
+                key={platform}
+                label={platform}
+                onClick={() => !isSubmitting && togglePlatform(platform)}
+                sx={{
+                  fontFamily: "Montserrat, sans-serif",
+                  fontWeight: selected ? 700 : 400,
+                  fontSize: "12px",
+                  backgroundColor: selected
+                    ? colors.warning
+                    : colors.isDark
+                    ? "rgba(255,255,255,0.08)"
+                    : "rgba(0,0,0,0.06)",
+                  color: selected
+                    ? "#000"
+                    : colors.textPrimary,
+                  border: selected
+                    ? `2px solid ${colors.warning}`
+                    : "2px solid transparent",
+                  cursor: "pointer",
+                  "&:hover": {
+                    backgroundColor: selected
+                      ? colors.warning
+                      : colors.isDark
+                      ? "rgba(255,255,255,0.14)"
+                      : "rgba(0,0,0,0.1)",
+                  },
+                }}
+              />
+            );
+          })}
+        </Box>
+      </Box>
+
+      {/* Media uploader */}
+      <Box>
+        <Typography
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontSize: "13px",
+            color: colors.textSecondary,
+            mb: 1,
+          }}
+        >
+          Media *
+        </Typography>
+        <VaultMediaUploader
+          mediaUrls={mediaUrls}
+          mediaType={mediaType}
+          onMediaChange={handleMediaChange}
+          disabled={isSubmitting}
+        />
+      </Box>
+
+      {/* Consent */}
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={consent}
+            onChange={(e) => setConsent(e.target.checked)}
+            disabled={isSubmitting}
+            sx={{
+              color: colors.isDark ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.4)",
+              "&.Mui-checked": { color: colors.warning },
+            }}
+          />
+        }
+        label={
+          <Typography
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontSize: "13px",
+              color: colors.textSecondary,
+            }}
+          >
+            I confirm I own this content or have rights to share it for
+            promotional use on The Sneaker Society platform. *
+          </Typography>
+        }
+      />
+
+      {/* Error */}
+      {formError && (
+        <Alert
+          severity="error"
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontSize: "13px",
+            borderRadius: "10px",
+          }}
+        >
+          {formError}
+        </Alert>
+      )}
+
+      {/* Actions */}
+      <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 700,
+            fontSize: "14px",
+            textTransform: "none",
+            backgroundColor: colors.warning,
+            color: "#000",
+            borderRadius: "10px",
+            px: 3,
+            py: 1,
+            "&:hover": { backgroundColor: "#e6b000" },
+            "&.Mui-disabled": { opacity: 0.6 },
+          }}
+        >
+          {isSubmitting ? (
+            <CircularProgress size={18} sx={{ color: "#000" }} />
+          ) : isEditMode ? (
+            "Save Changes"
+          ) : (
+            "Submit for Review"
+          )}
+        </Button>
+
+        {!isEditMode && (
+          <Button
+            variant="outlined"
+            onClick={handleSaveDraft}
+            disabled={isSubmitting}
+            sx={{
+              fontFamily: "Montserrat, sans-serif",
+              fontWeight: 600,
+              fontSize: "14px",
+              textTransform: "none",
+              borderColor: colors.isDark ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.25)",
+              color: colors.textSecondary,
+              borderRadius: "10px",
+              px: 3,
+              py: 1,
+              "&:hover": {
+                borderColor: colors.textPrimary,
+                color: colors.textPrimary,
+              },
+            }}
+          >
+            Save Draft
+          </Button>
+        )}
+
+        <Button
+          variant="text"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          sx={{
+            fontFamily: "Montserrat, sans-serif",
+            fontWeight: 600,
+            fontSize: "14px",
+            textTransform: "none",
+            color: colors.textSecondary,
+            "&:hover": { color: colors.textPrimary },
+          }}
+        >
+          Cancel
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default VaultSubmissionForm;


### PR DESCRIPTION
## Summary

- Created `VaultSubmissionForm.jsx` — create/edit form with title, description, category select, platform chip toggles, consent checkbox, and draft/submit modes
- Created `VaultMediaUploader.jsx` — image (up to 5) + video (1) uploader with blob previews, remove buttons, and upload progress
- Created `VaultSubmissionCard.jsx` — status-coded cards (pending/underReview/approved/rejected/published/draft) with edit, delete, and rejection alerts
- Created `VaultDetailModal.jsx` — admin modal with media viewer, approve/reject/feature/publish actions, and editable admin notes
- Created `VaultAdminQueue.jsx` — tabbed admin queue (All/Pending/Under Review/Approved/Rejected/Published) with quick actions and row-click detail view
- Rewrote `TheVault.jsx` from "coming soon" placeholder to full member dashboard with submission grid, empty state, and admin queue section
- Created `src/context/graphql/getVault.js` — all 10 GQL operations (queries + mutations)

## Trello Tickets

- https://trello.com/c/I1zmEfU2 — Frontend: Replace the Vault placeholder with member submission dashboard
- https://trello.com/c/CcjX7STS — Frontend: Build Vault submission form
- https://trello.com/c/Fhystkwp — Frontend: Add media uploader with preview states
- https://trello.com/c/RYDvuKTl — Frontend: Add consent and marketing permissions section
- https://trello.com/c/Y99wq3wj — Frontend: Build member submission list and status cards
- https://trello.com/c/RWwPGAPQ — Frontend: Add empty state for first-time Vault users
- https://trello.com/c/dQZ6Wv19 — Frontend: Add edit and delete actions for draft or pending submissions
- https://trello.com/c/OBqxbmRU — Frontend: Add admin moderation queue UI, submission detail drawer/modal, success/error/loading states

## Test plan

- [x] Member can open "Submit Your Work" modal and fill out the form
- [x] Media uploader accepts images (up to 5) and video (1) with previews
- [x] Draft save works without requiring consent checkbox
- [x] Submit requires title + media + consent
- [ ] Submission cards display correct status chips and colors
- [ ] Rejected submissions show admin notes in an alert
- [ ] Edit/Delete only visible for draft/pending submissions
- [x] Admin queue tabs filter correctly by status
- [ ] Admin can approve, reject (with notes), feature, and publish from detail modal